### PR TITLE
Add happy-path test cases for Model and ApiClient

### DIFF
--- a/.github/workflows/google_generative_ai.yml
+++ b/.github/workflows/google_generative_ai.yml
@@ -42,5 +42,5 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed .
         if: ${{matrix.run-tests}}
 
-      # - run: dart test
-      #   if: ${{matrix.run-tests}}
+      - run: dart test
+        if: ${{matrix.run-tests}}

--- a/pkgs/google_generative_ai/lib/src/client.dart
+++ b/pkgs/google_generative_ai/lib/src/client.dart
@@ -38,9 +38,11 @@ final class HttpApiClient implements ApiClient {
   @override
   Future<Map<String, Object?>> makeRequest(
       Uri uri, Map<String, Object?> body) async {
-    final response = await http.post(uri,
-        headers: {..._headers, 'Content-Type': 'application/json'},
-        body: utf8.encode(jsonEncode(body)));
+    final response = await http.post(
+      uri,
+      headers: {..._headers, 'Content-Type': 'application/json'},
+      body: utf8.encode(jsonEncode(body)),
+    );
     return jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, Object?>;
   }
 

--- a/pkgs/google_generative_ai/lib/src/client.dart
+++ b/pkgs/google_generative_ai/lib/src/client.dart
@@ -14,42 +14,44 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 
 abstract interface class ApiClient {
-  Future<String> makeRequest(Uri uri, Uint8List body);
-  Stream<String> streamRequest(Uri uri, Uint8List body);
+  Future<Map<String, Object?>> makeRequest(Uri uri, Map<String, Object?> body);
+  Stream<Map<String, Object?>> streamRequest(
+      Uri uri, Map<String, Object?> body);
 }
 
 const _packageVersion = '0.0.1';
-const _clientName = 'genai-dart/$_packageVersion';
+const clientName = 'genai-dart/$_packageVersion';
 
 final class HttpApiClient implements ApiClient {
   final String _apiKey;
   late final _headers = {
     'x-goog-api-key': _apiKey,
-    'x-goog-api-client': _clientName
+    'x-goog-api-client': clientName
   };
 
-  HttpApiClient({required String model, required String apiKey})
-      : _apiKey = apiKey;
+  HttpApiClient({required String apiKey}) : _apiKey = apiKey;
 
   @override
-  Future<String> makeRequest(Uri uri, Uint8List body) async {
+  Future<Map<String, Object?>> makeRequest(
+      Uri uri, Map<String, Object?> body) async {
     final response = await http.post(uri,
-        headers: {..._headers, 'Content-Type': 'application/json'}, body: body);
-    return utf8.decode(response.bodyBytes);
+        headers: {..._headers, 'Content-Type': 'application/json'},
+        body: utf8.encode(jsonEncode(body)));
+    return jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, Object?>;
   }
 
   @override
-  Stream<String> streamRequest(Uri uri, Uint8List body) {
-    final controller = StreamController<String>();
+  Stream<Map<String, Object?>> streamRequest(
+      Uri uri, Map<String, Object?> body) {
+    final controller = StreamController<Map<String, Object?>>();
     () async {
       uri = uri.replace(queryParameters: {'alt': 'sse'});
       final request = http.Request('POST', uri)
-        ..bodyBytes = body
+        ..bodyBytes = utf8.encode(jsonEncode(body))
         ..headers.addAll(_headers)
         ..headers['Content-Type'] = 'application/json';
       final response = await request.send();
@@ -58,6 +60,8 @@ final class HttpApiClient implements ApiClient {
           .transform(const LineSplitter())
           .where((line) => line.startsWith('data: '))
           .map((line) => line.substring(6))
+          .map(jsonDecode)
+          .cast<Map<String, Object?>>()
           .pipe(controller);
     }();
     return controller.stream;

--- a/pkgs/google_generative_ai/lib/src/content.dart
+++ b/pkgs/google_generative_ai/lib/src/content.dart
@@ -27,7 +27,10 @@ final class Content {
   static Content multi(Iterable<Part> parts) => Content('user', [...parts]);
   static Content model(Iterable<Part> parts) => Content('model', [...parts]);
 
-  Map toJson() => {if (role case final role?) 'role': role, 'parts': parts};
+  Map toJson() => {
+        if (role case final role?) 'role': role,
+        'parts': parts.map((p) => p.toJson()).toList()
+      };
 }
 
 Content parseContent(Object jsonObject) {
@@ -52,11 +55,14 @@ Part _parsePart(Object? jsonObject) {
 }
 
 /// A datatype containing media that is part of a multi-part [Content] message.
-sealed class Part {}
+sealed class Part {
+  Object toJson();
+}
 
 final class TextPart implements Part {
   final String text;
   TextPart(this.text);
+  @override
   Object toJson() => {'text': text};
 }
 
@@ -64,6 +70,7 @@ final class DataPart implements Part {
   final String mimeType;
   final Uint8List bytes;
   DataPart(this.mimeType, this.bytes);
+  @override
   Object toJson() => {
         'inlineData': {'data': base64Encode(bytes), 'mimeType': mimeType}
       };

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -42,23 +42,24 @@ final class GenerativeModel {
   final GenerationConfig? _generationConfig;
   final ApiClient _client;
 
-  factory GenerativeModel(
-          {required String model,
-          required String apiKey,
-          List<SafetySetting> safetySettings = const [],
-          GenerationConfig? generationConfig}) =>
+  factory GenerativeModel({
+    required String model,
+    required String apiKey,
+    List<SafetySetting> safetySettings = const [],
+    GenerationConfig? generationConfig,
+  }) =>
       GenerativeModel._withClient(
           client: HttpApiClient(apiKey: apiKey),
           model: model,
           safetySettings: safetySettings,
           generationConfig: generationConfig);
 
-  GenerativeModel._withClient(
-      {required ApiClient client,
-      required String model,
-      required List<SafetySetting> safetySettings,
-      required GenerationConfig? generationConfig})
-      :
+  GenerativeModel._withClient({
+    required ApiClient client,
+    required String model,
+    required List<SafetySetting> safetySettings,
+    required GenerationConfig? generationConfig,
+  })  :
         // TODO: Allow `models/` prefix and strip it.
         // https://github.com/google/generative-ai-js/blob/2be48f8e5427f2f6191f24bcb8000b450715a0de/packages/main/src/models/generative-model.ts#L59
         _model = model,
@@ -151,6 +152,9 @@ final class GenerativeModel {
   }
 }
 
+/// Create a model with an overridden [ApiClient] for testing.
+///
+/// Package private test only method.
 GenerativeModel createModelwithClient(
         {required String model,
         required ApiClient client,

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -10,10 +10,11 @@ environment:
   sdk: ^3.2.0
 
 dependencies:
-  crypt: ^4.3.0
   http: ^1.1.0
   pool: ^1.5.0
 
 dev_dependencies:
+  collection: ^1.18.0
   lints: ^3.0.0
+  matcher: ^0.12.16
   test: ^1.24.0

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -1,0 +1,154 @@
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:google_generative_ai/src/model.dart';
+import 'package:test/test.dart';
+
+import 'utils/stub_client.dart';
+import 'utils/matchers.dart';
+
+void main() {
+  group('GenerativeModel', () {
+    late GenerativeModel model;
+    late StubClient client;
+    const modelName = 'some-model';
+
+    setUp(() {
+      client = StubClient();
+      model = createModelwithClient(model: modelName, client: client);
+    });
+
+    group('generate unary content', () {
+      test('can make successful request', () async {
+        final prompt = 'Some prompt';
+        final result = 'Some response';
+        client.stub(
+            Uri.parse('https://generativelanguage.googleapis.com/v1/'
+                'models/some-model:generateContent'),
+            {
+              'contents': [
+                {
+                  'role': 'user',
+                  'parts': [
+                    {'text': prompt}
+                  ]
+                }
+              ]
+            },
+            {
+              'candidates': [
+                {
+                  'content': {
+                    'role': 'model',
+                    'parts': [
+                      {'text': result}
+                    ]
+                  }
+                }
+              ]
+            });
+        final response = await model.generateContent([Content.text(prompt)]);
+        expect(
+            response,
+            matchesGeenrateContentResponse(GenerateContentResponse([
+              Candidate(
+                  Content('model', [TextPart(result)]), null, null, null, null),
+            ], null)));
+      });
+    });
+
+    group('generate content stream', () {
+      test('can make successful request', () async {
+        final prompt = 'Some prompt';
+        final results = {'First response', 'Second Response'};
+        client.stubStream(
+            Uri.parse('https://generativelanguage.googleapis.com/v1/'
+                'models/some-model:streamGenerateContent'),
+            {
+              'contents': [
+                {
+                  'role': 'user',
+                  'parts': [
+                    {'text': prompt}
+                  ]
+                }
+              ]
+            },
+            [
+              for (final result in results)
+                {
+                  'candidates': [
+                    {
+                      'content': {
+                        'role': 'model',
+                        'parts': [
+                          {'text': result}
+                        ]
+                      }
+                    }
+                  ]
+                }
+            ]);
+        final response = model.generateContentStream([Content.text(prompt)]);
+        expect(
+            response,
+            emitsInOrder([
+              for (final result in results)
+                matchesGeenrateContentResponse(GenerateContentResponse([
+                  Candidate(Content('model', [TextPart(result)]), null, null,
+                      null, null),
+                ], null))
+            ]));
+      });
+    });
+
+    group('count tokens', () {
+      test('can make successful request', () async {
+        final prompt = 'Some prompt';
+        client.stub(
+            Uri.parse('https://generativelanguage.googleapis.com/v1/'
+                'models/some-model:countTokens'),
+            {
+              'contents': [
+                {
+                  'role': 'user',
+                  'parts': [
+                    {'text': prompt}
+                  ]
+                }
+              ]
+            },
+            {
+              'totalTokens': 2
+            });
+        final response = await model.countTokens([Content.text(prompt)]);
+        expect(response, matchesCountTokensResponse(CountTokensResponse(2)));
+      });
+    });
+
+    group('embed content', () {
+      test('can make successful request', () async {
+        final prompt = 'Some prompt';
+        client.stub(
+            Uri.parse('https://generativelanguage.googleapis.com/v1/'
+                'models/some-model:embedContent'),
+            {
+              'content': {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            },
+            {
+              'embedding': {
+                'values': [0.1, 0.2, 0.3]
+              }
+            });
+        final response = await model.embedContent(Content.text(prompt));
+        expect(
+            response,
+            matchesEmbedContentResponse(
+                EmbedContentResponse(ContentEmbedding([0.1, 0.2, 0.3]))));
+      });
+    });
+  });
+}

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -2,8 +2,8 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 import 'package:google_generative_ai/src/model.dart';
 import 'package:test/test.dart';
 
-import 'utils/stub_client.dart';
 import 'utils/matchers.dart';
+import 'utils/stub_client.dart';
 
 void main() {
   group('GenerativeModel', () {

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:google_generative_ai/google_generative_ai.dart';
 import 'package:google_generative_ai/src/model.dart';
 import 'package:test/test.dart';
@@ -21,30 +35,31 @@ void main() {
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
-            Uri.parse('https://generativelanguage.googleapis.com/v1/'
-                'models/some-model:generateContent'),
-            {
-              'contents': [
-                {
-                  'role': 'user',
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:generateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ]
+          },
+          {
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
                   'parts': [
-                    {'text': prompt}
+                    {'text': result}
                   ]
                 }
-              ]
-            },
-            {
-              'candidates': [
-                {
-                  'content': {
-                    'role': 'model',
-                    'parts': [
-                      {'text': result}
-                    ]
-                  }
-                }
-              ]
-            });
+              }
+            ]
+          },
+        );
         final response = await model.generateContent([Content.text(prompt)]);
         expect(
             response,
@@ -60,33 +75,34 @@ void main() {
         final prompt = 'Some prompt';
         final results = {'First response', 'Second Response'};
         client.stubStream(
-            Uri.parse('https://generativelanguage.googleapis.com/v1/'
-                'models/some-model:streamGenerateContent'),
-            {
-              'contents': [
-                {
-                  'role': 'user',
-                  'parts': [
-                    {'text': prompt}
-                  ]
-                }
-              ]
-            },
-            [
-              for (final result in results)
-                {
-                  'candidates': [
-                    {
-                      'content': {
-                        'role': 'model',
-                        'parts': [
-                          {'text': result}
-                        ]
-                      }
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:streamGenerateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ]
+          },
+          [
+            for (final result in results)
+              {
+                'candidates': [
+                  {
+                    'content': {
+                      'role': 'model',
+                      'parts': [
+                        {'text': result}
+                      ]
                     }
-                  ]
-                }
-            ]);
+                  }
+                ]
+              }
+          ],
+        );
         final response = model.generateContentStream([Content.text(prompt)]);
         expect(
             response,
@@ -128,21 +144,22 @@ void main() {
       test('can make successful request', () async {
         final prompt = 'Some prompt';
         client.stub(
-            Uri.parse('https://generativelanguage.googleapis.com/v1/'
-                'models/some-model:embedContent'),
-            {
-              'content': {
-                'role': 'user',
-                'parts': [
-                  {'text': prompt}
-                ]
-              }
-            },
-            {
-              'embedding': {
-                'values': [0.1, 0.2, 0.3]
-              }
-            });
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:embedContent'),
+          {
+            'content': {
+              'role': 'user',
+              'parts': [
+                {'text': prompt}
+              ]
+            }
+          },
+          {
+            'embedding': {
+              'values': [0.1, 0.2, 0.3]
+            }
+          },
+        );
         final response = await model.embedContent(Content.text(prompt));
         expect(
             response,

--- a/pkgs/google_generative_ai/test/http_api_client_test.dart
+++ b/pkgs/google_generative_ai/test/http_api_client_test.dart
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:convert';
 
 import 'package:google_generative_ai/src/client.dart';

--- a/pkgs/google_generative_ai/test/http_api_client_test.dart
+++ b/pkgs/google_generative_ai/test/http_api_client_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:google_generative_ai/src/client.dart';
+import 'package:test/test.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart' as http;
+
+import 'utils/matchers.dart';
+
+void main() {
+  group('HttpApiClient', () {
+    test('can make unary request', () async {
+      final url = Uri.parse('https://someurl.com');
+      final body = {'some': 'body'};
+      final apiKey = 'apiKey';
+      final expectedResponse = {'result': 'OK'};
+      await http.runWithClient(() async {
+        final client = HttpApiClient(apiKey: apiKey);
+        final response = await client.makeRequest(url, body);
+        expect(response, expectedResponse);
+      },
+          () => MockClient((request) async {
+                expect(
+                    request,
+                    matchesRequest(http.Request('POST', url)
+                      ..headers.addAll({
+                        'x-goog-api-key': apiKey,
+                        'x-goog-api-client': clientName,
+                        'Content-Type': 'application/json'
+                      })
+                      ..bodyBytes = utf8.encode(jsonEncode(body))));
+                return http.Response.bytes(
+                    utf8.encode(jsonEncode(expectedResponse)), 200);
+              }));
+    });
+
+    test('can make streaming request', () async {
+      final url = Uri.parse('https://someurl.com');
+      final streamingUrl = Uri.parse('https://someurl.com?alt=sse');
+      final body = {'some': 'body'};
+      final apiKey = 'apiKey';
+      final expectedResponses = [
+        {'first': 'OK'},
+        {'second': 'OK'}
+      ];
+      await http.runWithClient(() async {
+        final client = HttpApiClient(apiKey: apiKey);
+        final response = client.streamRequest(url, body);
+        await expectLater(
+            response, emitsInOrder([...expectedResponses, emitsDone]));
+      },
+          () => MockClient.streaming((request, requestStream) async {
+                expect(
+                    request,
+                    matchesBaseRequest(http.Request('POST', streamingUrl)
+                      ..headers.addAll({
+                        'x-goog-api-key': apiKey,
+                        'x-goog-api-client': clientName,
+                        'Content-Type': 'application/json'
+                      })));
+                expect(requestStream,
+                    emitsInOrder([utf8.encode(jsonEncode(body)), emitsDone]));
+                return http.StreamedResponse(
+                    Stream.fromIterable(expectedResponses)
+                        .map((r) => utf8.encode('data: ${jsonEncode(r)}\n')),
+                    200);
+              }));
+    });
+  });
+}

--- a/pkgs/google_generative_ai/test/http_api_client_test.dart
+++ b/pkgs/google_generative_ai/test/http_api_client_test.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
 import 'package:google_generative_ai/src/client.dart';
-import 'package:test/test.dart';
-import 'package:http/testing.dart';
 import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
 
 import 'utils/matchers.dart';
 

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:google_generative_ai/google_generative_ai.dart';
 import 'package:http/http.dart' as http;
 import 'package:matcher/matcher.dart';

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -1,0 +1,51 @@
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:matcher/matcher.dart';
+import 'package:http/http.dart' as http;
+
+Matcher matchesPart(Part part) => switch (part) {
+      TextPart(text: final text) =>
+        isA<TextPart>().having((p) => p.text, 'text', text),
+      DataPart(mimeType: final mimeType, bytes: final bytes) => isA<DataPart>()
+          .having((p) => p.mimeType, 'mimeType', mimeType)
+          .having((p) => p.bytes, 'bytes', bytes),
+    };
+
+Matcher matchesContent(Content content) => isA<Content>()
+    .having((c) => c.role, 'role', content.role)
+    .having((c) => c.parts, 'parts', content.parts.map(matchesPart).toList());
+
+Matcher matchesCandidate(Candidate candidate) => isA<Candidate>()
+    .having((c) => c.content, 'content', matchesContent(candidate.content));
+
+Matcher matchesGeenrateContentResponse(GenerateContentResponse response) =>
+    isA<GenerateContentResponse>()
+        .having((r) => r.candidates, 'candidates',
+            response.candidates.map(matchesCandidate).toList())
+        .having(
+            (r) => r.promptFeedback,
+            'promptFeedback',
+            response.promptFeedback == null
+                ? isNull
+                : throw UnimplementedError('Prompt Feedback Matching'));
+
+Matcher matchesEmbedding(ContentEmbedding embedding) =>
+    isA<ContentEmbedding>().having((e) => e.values, 'values', embedding.values);
+
+Matcher matchesEmbedContentResponse(EmbedContentResponse response) =>
+    isA<EmbedContentResponse>().having(
+        (r) => r.embedding, 'embedding', matchesEmbedding(response.embedding));
+
+Matcher matchesCountTokensResponse(CountTokensResponse response) =>
+    isA<CountTokensResponse>()
+        .having((r) => r.totalTokens, 'totalTokens', response.totalTokens);
+
+Matcher matchesRequest(http.Request request) => isA<http.Request>()
+    .having((r) => r.headers, 'headers', request.headers)
+    .having((r) => r.method, 'method', request.method)
+    .having((r) => r.bodyBytes, 'bodyBytes', request.bodyBytes)
+    .having((r) => r.url, 'url', request.url);
+
+Matcher matchesBaseRequest(http.BaseRequest request) => isA<http.BaseRequest>()
+    .having((r) => r.headers, 'headers', request.headers)
+    .having((r) => r.method, 'method', request.method)
+    .having((r) => r.url, 'url', request.url);

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -1,6 +1,6 @@
 import 'package:google_generative_ai/google_generative_ai.dart';
-import 'package:matcher/matcher.dart';
 import 'package:http/http.dart' as http;
+import 'package:matcher/matcher.dart';
 
 Matcher matchesPart(Part part) => switch (part) {
       TextPart(text: final text) =>

--- a/pkgs/google_generative_ai/test/utils/stub_client.dart
+++ b/pkgs/google_generative_ai/test/utils/stub_client.dart
@@ -1,0 +1,33 @@
+import 'package:google_generative_ai/src/client.dart';
+import 'package:collection/collection.dart';
+
+const Equality<Map<String, Object?>> _mapEquality =
+    MapEquality(values: DeepCollectionEquality());
+
+final class StubClient implements ApiClient {
+  final _requests =
+      EqualityMap<Map<String, Object?>, Map<String, Object?>>(_mapEquality);
+  final _streamRequests =
+      EqualityMap<Map<String, Object?>, Iterable<Map<String, Object?>>>(
+          _mapEquality);
+
+  void stub(Uri uri, Map<String, Object?> body, Map<String, Object?> result) =>
+      _requests[{'_hack_uri': uri, ...body}] = result;
+  void stubStream(Uri uri, Map<String, Object?> body,
+          Iterable<Map<String, Object?>> result) =>
+      _streamRequests[{'_hack_uri': uri, ...body}] = result;
+
+  @override
+  Future<Map<String, Object?>> makeRequest(
+          Uri uri, Map<String, Object?> body) =>
+      Future.value(_requests.remove({'_hack_uri': uri, ...body}) ??
+          (throw StateError(
+              'Missing stub for request to $uri with body $body')));
+
+  @override
+  Stream<Map<String, Object?>> streamRequest(
+          Uri uri, Map<String, Object?> body) =>
+      Stream.fromIterable(_streamRequests.remove({'_hack_uri': uri, ...body}) ??
+          (throw StateError(
+              'Missing stub for request to $uri with body $body')));
+}

--- a/pkgs/google_generative_ai/test/utils/stub_client.dart
+++ b/pkgs/google_generative_ai/test/utils/stub_client.dart
@@ -1,5 +1,5 @@
-import 'package:google_generative_ai/src/client.dart';
 import 'package:collection/collection.dart';
+import 'package:google_generative_ai/src/client.dart';
 
 const Equality<Map<String, Object?>> _mapEquality =
     MapEquality(values: DeepCollectionEquality());

--- a/pkgs/google_generative_ai/test/utils/stub_client.dart
+++ b/pkgs/google_generative_ai/test/utils/stub_client.dart
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'package:collection/collection.dart';
 import 'package:google_generative_ai/src/client.dart';
 


### PR DESCRIPTION
Refactor `ApiClient` to go from `Map` to `Map` instead of bytes to
`String`. This makes it easier to write a stub client which is agnostic
to the ordering of values in the maps. Move the responsibilities for
UTF8 and JSON encoding to the `HttpApiClient`.

Eagerly call nested `.toJson()` methods for child fields in `.toJson()`
implementations. This allows deep equality checking for the stub client
without implementing `operator ==` for the data model classes.

Add a `createModelWithClient` method in `src/model.dart` which will not
be exported to the package public API. Use it in the test to create a
model with a stubbed client.

Add tests for each call in `GenerativeModel`. Tests validate
- Encoding from arguments to the JSON schema.
- Building the correct `Uri` for the task and model.
- Parsing the result to the Dart data model.

Add tests for unary and streaming calls in `HttpClient`. Tests validate
- Headers are set correctly.
- Encoding and decoding UTF8 and JSON.
- Using streaming with `alt=sse` query parameter and parsing of `data: `
  lines in the response.

Add Matcher helper methods for classes checked during tests that don't
have `operator ==`.
