### PR TITLE
Normalize model names

### DIFF
--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -62,13 +62,16 @@ final class GenerativeModel {
     required String model,
     required List<SafetySetting> safetySettings,
     required GenerationConfig? generationConfig,
-  })  :
-        // TODO: Allow `models/` prefix and strip it.
-        // https://github.com/google/generative-ai-js/blob/2be48f8e5427f2f6191f24bcb8000b450715a0de/packages/main/src/models/generative-model.ts#L59
-        _model = model,
+  })  : _model = _normalizeModelName(model),
         _safetySettings = safetySettings,
         _generationConfig = generationConfig,
         _client = client;
+
+  static const _modelsPrefix = 'models/';
+  static String _normalizeModelName(String modelName) =>
+      modelName.startsWith(_modelsPrefix)
+          ? modelName.substring(_modelsPrefix.length)
+          : modelName;
 
   Uri _taskUri(Task task) => _baseUrl.resolveUri(
       Uri(pathSegments: [_apiVersion, 'models', '$_model:${task._name}']));

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -44,6 +44,13 @@ final class GenerativeModel {
   final GenerationConfig? _generationConfig;
   final ApiClient _client;
 
+  /// Create a [GenerativeModel] backed by the generative modeal named [model].
+  ///
+  /// The [model] argument can be a model name (such as `'gemini-pro'`) or a
+  /// model code (such as `'models/gemini-pro'`).
+  ///
+  /// A default [http.Client] will be created for each request.
+  /// Pass a [httpClient] to override with a custom client instance.
   factory GenerativeModel({
     required String model,
     required String apiKey,


### PR DESCRIPTION
Strip a leading `models/` since the model names are often used with that
prefix. Store the field without the prefix so it can be used as a URI
path segment and no URI parts are constructed with string operations.

Change a call to `setUp` to define a method called from each test to
allow one case where the model name is overidden. Add a single test that
validates the  URI does not have a double `models/` segment.
