### PR TITLE
Adjust temperature and topP types in GenerationConfig

### DIFF
--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -207,8 +207,8 @@ final class GenerationConfig {
   final int? candidateCount;
   final List<String> stopSequences;
   final int? maxOutputTokens;
-  final int? temperature;
-  final int? topP;
+  final double? temperature;
+  final double? topP;
   final int? topK;
   GenerationConfig(
       {this.candidateCount,


### PR DESCRIPTION
## Update `GenerationConfig` Class Field Types

This commit updates the `GenerationConfig` class to use `double?` instead of `int?` for the `temperature` and `topP` fields. 

This change aligns the Dart implementation with [Google's AI API Reference](https://ai.google.dev/api/rest/v1/GenerationConfig), which specifies these fields as numbers capable of holding fractional values. 

The adjustment ensures compatibility with the API's expected input types for controlling randomness (`temperature`) and the cumulative probability threshold (`topP`) in generated responses.

### Changes Made
- Change `temperature` field type from `int?` to `double?`
- Change `topP` field type from `int?` to `double?`

### Supporting Evidence

Below are screenshots from Google AI Studio's code generation examples in Python and Koltin, highlighting the usage of `temperature` and `topP` as non-integer (floating-point) values, supporting the need for these changes in the Dart implementation.

#### Python Example
<img width="793" alt="Screenshot 2024-02-01 at 5 48 49 PM" src="https://github.com/google/generative-ai-dart/assets/5323628/1214bf79-5210-423a-84b4-9544e774b6d6">


#### Kotlin Example
<img width="824" alt="Screenshot 2024-02-01 at 5 49 29 PM" src="https://github.com/google/generative-ai-dart/assets/5323628/7cdb9653-ddc6-4a17-842e-290bb1f222af">

