### PR TITLE
Add parsing for unary server errors

### DIFF
--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -57,4 +57,10 @@ export 'src/api.dart'
         TaskType;
 export 'src/chat.dart' show ChatSession, StartChatExtension;
 export 'src/content.dart' show Content, DataPart, Part, TextPart;
+export 'src/error.dart'
+    show
+        GenerativeAIException,
+        InvalidApiKey,
+        ServerException,
+        UnsupportedUserLocation;
 export 'src/model.dart' show GenerativeModel;

--- a/pkgs/google_generative_ai/lib/src/error.dart
+++ b/pkgs/google_generative_ai/lib/src/error.dart
@@ -12,11 +12,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// Exception thrown when generating content fails.
+///
+/// The [message] may explain the cause of the failure.
 final class GenerativeAIException implements Exception {
   final String message;
 
   GenerativeAIException(this.message);
 
   @override
-  String toString() => 'GenerateiveAIException: $message';
+  String toString() => 'GenerativeAIException: $message';
+}
+
+/// Exception thrown when the server rejects the API key.
+final class InvalidApiKey implements GenerativeAIException {
+  @override
+  final String message;
+
+  InvalidApiKey(this.message);
+
+  @override
+  String toString() => message;
+}
+
+/// Exception thrown when the user location is unsupported.
+final class UnsupportedUserLocation implements GenerativeAIException {
+  static const _message = 'User location is not supported for the API use.';
+  @override
+  String get message => _message;
+}
+
+/// Exception thrown when the server failed to generate content.
+final class ServerException implements GenerativeAIException {
+  @override
+  final String message;
+
+  ServerException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+GenerativeAIException parseError(Object jsonObject) {
+  return switch (jsonObject) {
+    {
+      'message': final String message,
+      'details': [{'reason': 'API_KEY_INVALID'}, ...]
+    } =>
+      InvalidApiKey(message),
+    {'message': UnsupportedUserLocation._message} => UnsupportedUserLocation(),
+    {'message': final String message} => ServerException(message),
+    _ => throw FormatException('Unhandled Server Error format', jsonObject)
+  };
 }

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -104,7 +104,6 @@ final class GenerativeModel {
     try {
       return parseGenerateContentResponse(response);
     } on FormatException {
-      // TODO - will the HTTP request fail?
       if (response case {'error': final Object error}) {
         throw parseError(error);
       }

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -19,6 +19,7 @@ import 'package:http/http.dart' as http;
 import 'api.dart';
 import 'client.dart';
 import 'content.dart';
+import 'error.dart';
 
 final _baseUrl = Uri.https('generativelanguage.googleapis.com');
 const _apiVersion = 'v1';
@@ -100,7 +101,15 @@ final class GenerativeModel {
     };
     final response =
         await _client.makeRequest(_taskUri(Task.generateContent), parameters);
-    return parseGenerateContentResponse(response);
+    try {
+      return parseGenerateContentResponse(response);
+    } on FormatException {
+      // TODO - will the HTTP request fail?
+      if (response case {'error': final Object error}) {
+        throw parseError(error);
+      }
+      rethrow;
+    }
   }
 
   /// Returns a stream of content responding to [prompt].

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import 'package:google_generative_ai/google_generative_ai.dart';
 import 'package:google_generative_ai/src/model.dart';
 import 'package:test/test.dart';
@@ -107,6 +109,131 @@ void main() {
               Candidate(
                   Content('model', [TextPart(result)]), null, null, null, null),
             ], null)));
+      });
+
+      test('throws errors for invalid API key', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        final response = '''
+{
+  "error": {
+    "code": 400,
+    "message": "API key not valid. Please pass a valid API key.",
+    "status": "INVALID_ARGUMENT",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "API_KEY_INVALID",
+        "domain": "googleapis.com",
+        "metadata": {
+          "service": "generativelanguage.googleapis.com"
+        }
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "Invalid API key: AIzv00G7VmUCUeC-5OglO3hcXM"
+      }
+    ]
+  }
+}
+''';
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:generateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ]
+          },
+          jsonDecode(response) as Map<String, Object?>,
+        );
+        expect(
+          model.generateContent([Content.text(prompt)]),
+          throwsA(isA<InvalidApiKey>()),
+        );
+      });
+
+      test('throws errors for unsupported user location', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        final response = r'''
+{
+  "error": {
+    "code": 400,
+    "message": "User location is not supported for the API use.",
+    "status": "FAILED_PRECONDITION",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::failed_precondition: User location is not supported for the API use. [google.rpc.error_details_ext] { message: \"User location is not supported for the API use.\" }"
+      }
+    ]
+  }
+}
+''';
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:generateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ]
+          },
+          jsonDecode(response) as Map<String, Object?>,
+        );
+        expect(
+          model.generateContent([Content.text(prompt)]),
+          throwsA(isA<UnsupportedUserLocation>()),
+        );
+      });
+
+      test('throws general server errors', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        final response = r'''
+{
+  "error": {
+    "code": 404,
+    "message": "models/unknown is not found for API version v1, or is not supported for GenerateContent. Call ListModels to see the list of available models and their supported methods.",
+    "status": "NOT_FOUND",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::not_found: models/unknown is not found for API version v1, or is not supported for GenerateContent. Call ListModels to see the list of available models and their supported methods. [google.rpc.error_details_ext] { message: \"models/unknown is not found for API version v1, or is not supported for GenerateContent. Call ListModels to see the list of available models and their supported methods.\" }"
+      }
+    ]
+  }
+}
+''';
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:generateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ]
+          },
+          jsonDecode(response) as Map<String, Object?>,
+        );
+        expect(
+          model.generateContent([Content.text(prompt)]),
+          throwsA(isA<ServerException>()),
+        );
       });
     });
 


### PR DESCRIPTION
When parsing to a `GenerateContentResponse` fails with a format
exception, it may be due to the server responding with an "error"
response.

Add specific exception types for `InvalidApiKey` and
`UnsupportedUserLocation` since these errors may need specific handling
in a client. For now all other errors are a `ServerException`, but we
can add other types if it becomes useful to match more specific
patterns.

Add tests with scraped server error responses parsed to each error type.

Export the errors from the package public API.

Add a doc comment to the `GenerativeAIException` class from
https://github.com/google/generative-ai-dart/pull/28/files#diff-422b60b8e6460903ebe4ea03bef1a87c07ba50229d3f46bf436dc8ddd905d050

Fix a typo in the exception `toString()`.
