### PR TITLE
Add tests for parsing known server responses

### DIFF
--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -57,4 +57,5 @@ export 'src/api.dart'
         TaskType;
 export 'src/chat.dart' show ChatSession, StartChatExtension;
 export 'src/content.dart' show Content, DataPart, Part, TextPart;
+export 'src/error.dart' show GenerativeAIException;
 export 'src/model.dart' show GenerativeModel;

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -44,7 +44,8 @@ final class GenerateContentResponse {
             :final blockReason,
             :final blockReasonMessage,
           ) =>
-            throw GenerativeAIException('Reponse was blocked'
+            // TODO: Add a specific subtype for this exception?
+            throw GenerativeAIException('Response was blocked'
                 '${blockReason != null ? ' due to $blockReason' : ''}'
                 '${blockReasonMessage != null ? ': $blockReasonMessage' : ''}'),
           _ => null,
@@ -255,8 +256,10 @@ GenerateContentResponse parseGenerateContentResponse(Object jsonObject) {
             _parsePromptFeedback(promptFeedback),
           _ => null
         }),
+    {'promptFeedback': final Map promptFeedback} =>
+      GenerateContentResponse([], _parsePromptFeedback(promptFeedback)),
     _ => throw FormatException(
-        'Unhandled GenerateContentResponse format: $jsonObject')
+        'Unhandled GenerateContentResponse format', jsonObject)
   };
 }
 
@@ -264,16 +267,16 @@ CountTokensResponse parseCountTokensResponse(Object jsonObject) {
   return switch (jsonObject) {
     {'totalTokens': final int totalTokens} => CountTokensResponse(totalTokens),
     _ =>
-      throw FormatException('Unhandled CountTokensReponse format: $jsonObject')
+      throw FormatException('Unhandled CountTokensResponse format', jsonObject)
   };
 }
 
-EmbedContentResponse parseEmbedContentReponse(Object jsonObject) {
+EmbedContentResponse parseEmbedContentResponse(Object jsonObject) {
   return switch (jsonObject) {
     {'embedding': final Object embedding} =>
       EmbedContentResponse(_parseContentEmbedding(embedding)),
-    _ => throw FormatException(
-        'Unhandled EmbedContentResponse format: $jsonObject')
+    _ =>
+      throw FormatException('Unhandled EmbedContentResponse format', jsonObject)
   };
 }
 
@@ -303,7 +306,7 @@ Candidate _parseCandidate(Object? jsonObject) {
             {'finishMessage': final String finishMessage} => finishMessage,
             _ => null
           }),
-    _ => throw FormatException('Unhandled Candidate format: $jsonObject'),
+    _ => throw FormatException('Unhandled Candidate format', jsonObject),
   };
 }
 
@@ -324,7 +327,7 @@ PromptFeedback _parsePromptFeedback(Object jsonObject) {
             _ => null,
           },
           safetyRatings.map(_parseSafetyRating).toList()),
-    _ => throw FormatException('Unhandled PromptFeedback format $jsonObject'),
+    _ => throw FormatException('Unhandled PromptFeedback format', jsonObject),
   };
 }
 
@@ -336,7 +339,7 @@ SafetyRating _parseSafetyRating(Object? jsonObject) {
     } =>
       SafetyRating(
           _parseHarmCategory(category), _parseHarmProbability(probability)),
-    _ => throw FormatException('Unhandled SafetyRating format $jsonObject'),
+    _ => throw FormatException('Unhandled SafetyRating format', jsonObject),
   };
 }
 
@@ -345,7 +348,7 @@ ContentEmbedding _parseContentEmbedding(Object? jsonObject) {
     {'values': final List values} => ContentEmbedding(<double>[
         ...values.cast<double>(),
       ]),
-    _ => throw FormatException('Unhandled ContentEmbedding format $jsonObject'),
+    _ => throw FormatException('Unhandled ContentEmbedding format', jsonObject),
   };
 }
 
@@ -356,7 +359,7 @@ HarmCategory _parseHarmCategory(Object jsonObject) {
     'HARM_CATEGORY_HATE_SPEECH' => HarmCategory.hateSpeech,
     'HARM_CATEGORY_SEXUALLY_EXPLICIT' => HarmCategory.sexuallyExplicit,
     'HARM_CATEGORY_DANGEROUS_CONTENT' => HarmCategory.dangerousContent,
-    _ => throw FormatException('Unhandled HarmCategory format $jsonObject'),
+    _ => throw FormatException('Unhandled HarmCategory format', jsonObject),
   };
 }
 
@@ -368,7 +371,7 @@ HarmProbability _parseHarmProbability(Object jsonObject) {
     'LOW' => HarmProbability.low,
     'MEDIUM' => HarmProbability.medium,
     'HIGH' => HarmProbability.high,
-    _ => throw FormatException('Unhandled HarmPropbability format $jsonObject'),
+    _ => throw FormatException('Unhandled HarmPropbability format', jsonObject),
   };
 }
 
@@ -376,7 +379,7 @@ CitationMetadata _parseCitationMetadata(Object? jsonObject) {
   return switch (jsonObject) {
     {'citationSources': final List<Object?> citationSources} =>
       CitationMetadata(citationSources.map(_parseCitationSource).toList()),
-    _ => throw FormatException('Unhandled CitationMetadata format $jsonObject'),
+    _ => throw FormatException('Unhandled CitationMetadata format', jsonObject),
   };
 }
 
@@ -389,7 +392,7 @@ CitationSource _parseCitationSource(Object? jsonObject) {
       'license': final String license,
     } =>
       CitationSource(startIndex, endIndex, Uri.parse(uri), license),
-    _ => throw FormatException('Unhandled CitationSource format $jsonObject'),
+    _ => throw FormatException('Unhandled CitationSource format', jsonObject),
   };
 }
 
@@ -402,7 +405,7 @@ FinishReason _parseFinishReason(Object jsonObject) {
     'SAFETY' => FinishReason.safety,
     'RECITATION' => FinishReason.recitation,
     'OTHER' => FinishReason.other,
-    _ => throw FormatException('Unhandled FinishReason format $jsonObject'),
+    _ => throw FormatException('Unhandled FinishReason format', jsonObject),
   };
 }
 
@@ -412,6 +415,6 @@ BlockReason _parseBlockReason(String jsonObject) {
     'UNSPECIFIED' => BlockReason.unspecified,
     'SAFETY' => BlockReason.safety,
     'OTHER' => BlockReason.other,
-    _ => throw FormatException('Unhandled BlockReason format $jsonObject'),
+    _ => throw FormatException('Unhandled BlockReason format', jsonObject),
   };
 }

--- a/pkgs/google_generative_ai/lib/src/content.dart
+++ b/pkgs/google_generative_ai/lib/src/content.dart
@@ -41,7 +41,7 @@ Content parseContent(Object jsonObject) {
           _ => null,
         },
         parts.map(_parsePart).toList()),
-    _ => throw FormatException('Unhandled Content format $jsonObject'),
+    _ => throw FormatException('Unhandled Content format', jsonObject),
   };
 }
 
@@ -50,7 +50,7 @@ Part _parsePart(Object? jsonObject) {
     {'text': String text} => TextPart(text),
     {'inlineData': {'mimeType': String _, 'data': String _}} =>
       throw UnimplementedError('inlineData content part not yet supported'),
-    _ => throw FormatException('Unhandled Part format $jsonObject'),
+    _ => throw FormatException('Unhandled Part format', jsonObject),
   };
 }
 

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -161,7 +161,7 @@ final class GenerativeModel {
     };
     final response =
         await _client.makeRequest(_taskUri(Task.embedContent), parameters);
-    return parseEmbedContentReponse(response);
+    return parseEmbedContentResponse(response);
   }
 }
 

--- a/pkgs/google_generative_ai/test/response_parsing_test.dart
+++ b/pkgs/google_generative_ai/test/response_parsing_test.dart
@@ -1,0 +1,316 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:google_generative_ai/src/api.dart';
+import 'package:test/test.dart';
+
+import 'utils/matchers.dart';
+
+void main() {
+  group('throws errors for invalid GenerateContentResponse', () {
+    test('with empty content', () {
+      final response = '''
+{
+  "candidates": [
+    {
+      "content": {},
+      "index": 0
+    }
+  ],
+  "promptFeedback": {
+    "safetyRatings": [
+      {
+        "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HATE_SPEECH",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HARASSMENT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+        "probability": "NEGLIGIBLE"
+      }
+    ]
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      expect(
+          () => parseGenerateContentResponse(decoded),
+          throwsA(isA<FormatException>().having((e) => e.message, 'message',
+              startsWith('Unhandled Content format'))));
+    });
+
+    test('with a blocked prompt', () {
+      final response = '''
+{
+  "promptFeedback": {
+    "blockReason": "SAFETY",
+    "safetyRatings": [
+      {
+        "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HATE_SPEECH",
+        "probability": "HIGH"
+      },
+      {
+        "category": "HARM_CATEGORY_HARASSMENT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+        "probability": "NEGLIGIBLE"
+      }
+    ]
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse = parseGenerateContentResponse(decoded);
+      expect(
+          generateContentResponse,
+          matchesGeenrateContentResponse(GenerateContentResponse(
+              [],
+              PromptFeedback(BlockReason.safety, null, [
+                SafetyRating(
+                    HarmCategory.sexuallyExplicit, HarmProbability.negligible),
+                SafetyRating(HarmCategory.hateSpeech, HarmProbability.high),
+                SafetyRating(
+                    HarmCategory.harassment, HarmProbability.negligible),
+                SafetyRating(
+                    HarmCategory.dangerousContent, HarmProbability.negligible),
+              ]))));
+      expect(
+          () => generateContentResponse.text,
+          throwsA(isA<GenerativeAIException>().having((e) => e.message,
+              'message', startsWith('Response was blocked due to safety'))));
+    });
+  });
+
+  group('parses successful GenerateContentResponse', () {
+    test('with a basic reply', () async {
+      final response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Mountain View, California, United States"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "safetyRatings": [
+        {
+          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HATE_SPEECH",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HARASSMENT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+          "probability": "NEGLIGIBLE"
+        }
+      ]
+    }
+  ],
+  "promptFeedback": {
+    "safetyRatings": [
+      {
+        "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HATE_SPEECH",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HARASSMENT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+        "probability": "NEGLIGIBLE"
+      }
+    ]
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse = parseGenerateContentResponse(decoded);
+      expect(
+          generateContentResponse,
+          matchesGeenrateContentResponse(GenerateContentResponse(
+              [
+                Candidate(
+                    Content.model(
+                        [TextPart('Mountain View, California, United States')]),
+                    [
+                      SafetyRating(HarmCategory.sexuallyExplicit,
+                          HarmProbability.negligible),
+                      SafetyRating(
+                          HarmCategory.hateSpeech, HarmProbability.negligible),
+                      SafetyRating(
+                          HarmCategory.harassment, HarmProbability.negligible),
+                      SafetyRating(HarmCategory.dangerousContent,
+                          HarmProbability.negligible),
+                    ],
+                    null,
+                    FinishReason.stop,
+                    null),
+              ],
+              PromptFeedback(null, null, [
+                SafetyRating(
+                    HarmCategory.sexuallyExplicit, HarmProbability.negligible),
+                SafetyRating(
+                    HarmCategory.hateSpeech, HarmProbability.negligible),
+                SafetyRating(
+                    HarmCategory.harassment, HarmProbability.negligible),
+                SafetyRating(
+                    HarmCategory.dangerousContent, HarmProbability.negligible),
+              ]))));
+    });
+
+    test('with a citation', () async {
+      final response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "placeholder"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "safetyRatings": [
+        {
+          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HATE_SPEECH",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HARASSMENT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+          "probability": "NEGLIGIBLE"
+        }
+      ],
+      "citationMetadata": {
+        "citationSources": [
+          {
+            "startIndex": 574,
+            "endIndex": 705,
+            "uri": "https://example.com/",
+            "license": ""
+          },
+          {
+            "startIndex": 899,
+            "endIndex": 1026,
+            "uri": "https://example.com/",
+            "license": ""
+          }
+        ]
+      }
+    }
+  ],
+  "promptFeedback": {
+    "safetyRatings": [
+      {
+        "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HATE_SPEECH",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_HARASSMENT",
+        "probability": "NEGLIGIBLE"
+      },
+      {
+        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+        "probability": "NEGLIGIBLE"
+      }
+    ]
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse = parseGenerateContentResponse(decoded);
+      expect(
+          generateContentResponse,
+          matchesGeenrateContentResponse(GenerateContentResponse(
+              [
+                Candidate(
+                    Content.model([TextPart('placeholder')]),
+                    [
+                      SafetyRating(HarmCategory.sexuallyExplicit,
+                          HarmProbability.negligible),
+                      SafetyRating(
+                          HarmCategory.hateSpeech, HarmProbability.negligible),
+                      SafetyRating(
+                          HarmCategory.harassment, HarmProbability.negligible),
+                      SafetyRating(HarmCategory.dangerousContent,
+                          HarmProbability.negligible),
+                    ],
+                    CitationMetadata([
+                      CitationSource(
+                          574, 705, Uri.https('example.com', ''), ''),
+                      CitationSource(
+                          899, 1026, Uri.https('example.com', ''), ''),
+                    ]),
+                    FinishReason.stop,
+                    null),
+              ],
+              PromptFeedback(null, null, [
+                SafetyRating(
+                    HarmCategory.sexuallyExplicit, HarmProbability.negligible),
+                SafetyRating(
+                    HarmCategory.hateSpeech, HarmProbability.negligible),
+                SafetyRating(
+                    HarmCategory.harassment, HarmProbability.negligible),
+                SafetyRating(
+                    HarmCategory.dangerousContent, HarmProbability.negligible),
+              ]))));
+    });
+  });
+}

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -40,7 +40,22 @@ Matcher matchesGeenrateContentResponse(GenerateContentResponse response) =>
             'promptFeedback',
             response.promptFeedback == null
                 ? isNull
-                : throw UnimplementedError('Prompt Feedback Matching'));
+                : matchesPromptFeedback(response.promptFeedback!));
+
+Matcher matchesPromptFeedback(PromptFeedback promptFeedback) =>
+    isA<PromptFeedback>()
+        .having((p) => p.blockReason, 'blockReason', promptFeedback.blockReason)
+        .having((p) => p.blockReasonMessage, 'blockReasonMessage',
+            promptFeedback.blockReasonMessage)
+        .having(
+            (p) => p.safetyRatings,
+            'safetyRatings',
+            unorderedMatches(
+                promptFeedback.safetyRatings.map(matchesSafetyRating)));
+
+Matcher matchesSafetyRating(SafetyRating safetyRating) => isA<SafetyRating>()
+    .having((s) => s.category, 'category', safetyRating.category)
+    .having((s) => s.probability, 'probability', safetyRating.probability);
 
 Matcher matchesEmbedding(ContentEmbedding embedding) =>
     isA<ContentEmbedding>().having((e) => e.values, 'values', embedding.values);


### PR DESCRIPTION
Copy some known server responses from the Android SDK repo.
https://github.com/google/generative-ai-android/tree/main/generativeai/src/test/resources/golden-files/unary

Add tests for parsing a `GenerateContentResponse` from each server
response.

Support parsing a response with no candidates that has a prompt
feedback.

Add prompt feedback matching to the testing utilities.

Move the JSON object from the message string to the "source" argument
when throwing a `FormatException` as suggested in
https://github.com/google/generative-ai-dart/pull/28

Fix some typos.
