### PR TITLE
Allow overriding config per request

### DIFF
--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -89,13 +89,16 @@ final class GenerativeModel {
   ///
   ///     final response = await model.generateContent([Content.text(prompt)]);
   ///     print(response.text);
-  Future<GenerateContentResponse> generateContent(
-      Iterable<Content> prompt) async {
+  Future<GenerateContentResponse> generateContent(Iterable<Content> prompt,
+      {List<SafetySetting>? safetySettings,
+      GenerationConfig? generationConfig}) async {
+    safetySettings ??= _safetySettings;
+    generationConfig ??= _generationConfig;
     final parameters = {
       'contents': prompt.map((p) => p.toJson()).toList(),
-      if (_safetySettings.isNotEmpty)
-        'safetySettings': _safetySettings.map((s) => s.toJson()).toList(),
-      if (_generationConfig case final config?)
+      if (safetySettings.isNotEmpty)
+        'safetySettings': safetySettings.map((s) => s.toJson()).toList(),
+      if (generationConfig case final config?)
         'generationConfig': config.toJson(),
     };
     final response =
@@ -112,12 +115,16 @@ final class GenerativeModel {
   ///       print(response.text);
   ///     }
   Stream<GenerateContentResponse> generateContentStream(
-      Iterable<Content> prompt) {
+      Iterable<Content> prompt,
+      {List<SafetySetting>? safetySettings,
+      GenerationConfig? generationConfig}) {
+    safetySettings ??= _safetySettings;
+    generationConfig ??= _generationConfig;
     final parameters = <String, Object?>{
       'contents': prompt.map((p) => p.toJson()).toList(),
-      if (_safetySettings.isNotEmpty)
-        'safetySettings': _safetySettings.map((s) => s.toJson()).toList(),
-      if (_generationConfig case final config?)
+      if (safetySettings.isNotEmpty)
+        'safetySettings': safetySettings.map((s) => s.toJson()).toList(),
+      if (generationConfig case final config?)
         'generationConfig': config.toJson(),
     };
     final response =

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -108,6 +108,98 @@ void main() {
                   Content('model', [TextPart(result)]), null, null, null, null),
             ], null)));
       });
+
+      test('can override safety settings', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        final result = 'Some response';
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:generateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ],
+            'safetySettings': [
+              {
+                'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',
+                'threshold': 'BLOCK_ONLY_HIGH'
+              }
+            ],
+          },
+          {
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': result}
+                  ]
+                }
+              }
+            ]
+          },
+        );
+        final response = await model.generateContent([
+          Content.text(prompt)
+        ], safetySettings: [
+          SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high)
+        ]);
+        expect(
+            response,
+            matchesGeenrateContentResponse(GenerateContentResponse([
+              Candidate(
+                  Content('model', [TextPart(result)]), null, null, null, null),
+            ], null)));
+      });
+
+      test('can override generation config', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        final result = 'Some response';
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:generateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ],
+            'generationConfig': {
+              'stopSequences': ['a']
+            },
+          },
+          {
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': result}
+                  ]
+                }
+              }
+            ]
+          },
+        );
+        final response = await model.generateContent([Content.text(prompt)],
+            generationConfig: GenerationConfig(stopSequences: ['a']));
+        expect(
+            response,
+            matchesGeenrateContentResponse(GenerateContentResponse([
+              Candidate(
+                  Content('model', [TextPart(result)]), null, null, null, null),
+            ], null)));
+      });
     });
 
     group('generate content stream', () {
@@ -145,6 +237,110 @@ void main() {
           ],
         );
         final response = model.generateContentStream([Content.text(prompt)]);
+        expect(
+            response,
+            emitsInOrder([
+              for (final result in results)
+                matchesGeenrateContentResponse(GenerateContentResponse([
+                  Candidate(Content('model', [TextPart(result)]), null, null,
+                      null, null),
+                ], null))
+            ]));
+      });
+
+      test('can override safety settings', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        final results = {'First response', 'Second Response'};
+        client.stubStream(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:streamGenerateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ],
+            'safetySettings': [
+              {
+                'category': 'HARM_CATEGORY_DANGEROUS_CONTENT',
+                'threshold': 'BLOCK_ONLY_HIGH'
+              }
+            ],
+          },
+          [
+            for (final result in results)
+              {
+                'candidates': [
+                  {
+                    'content': {
+                      'role': 'model',
+                      'parts': [
+                        {'text': result}
+                      ]
+                    }
+                  }
+                ]
+              }
+          ],
+        );
+        final response = model.generateContentStream([
+          Content.text(prompt)
+        ], safetySettings: [
+          SafetySetting(HarmCategory.dangerousContent, HarmBlockThreshold.high)
+        ]);
+        expect(
+            response,
+            emitsInOrder([
+              for (final result in results)
+                matchesGeenrateContentResponse(GenerateContentResponse([
+                  Candidate(Content('model', [TextPart(result)]), null, null,
+                      null, null),
+                ], null))
+            ]));
+      });
+
+      test('can override generation config', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        final results = {'First response', 'Second Response'};
+        client.stubStream(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:streamGenerateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ],
+            'generationConfig': {
+              'stopSequences': ['a']
+            },
+          },
+          [
+            for (final result in results)
+              {
+                'candidates': [
+                  {
+                    'content': {
+                      'role': 'model',
+                      'parts': [
+                        {'text': result}
+                      ]
+                    }
+                  }
+                ]
+              }
+          ],
+        );
+        final response = model.generateContentStream([Content.text(prompt)],
+            generationConfig: GenerationConfig(stopSequences: ['a']));
         expect(
             response,
             emitsInOrder([


### PR DESCRIPTION
Closes #35

Add a `safetySettings` and `generationConfig` argument to
`generateContent` and `generateContentStream`.
