### PR TITLE
Fix wire format for unspecified block reason

### DIFF
--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -158,7 +158,6 @@ final class SafetyRating {
 
 /// The reason why a prompt was blocked.
 enum BlockReason {
-  unknown,
   unspecified,
   safety,
   other;
@@ -521,8 +520,7 @@ FinishReason _parseFinishReason(Object jsonObject) {
 
 BlockReason _parseBlockReason(String jsonObject) {
   return switch (jsonObject) {
-    'UNKNOWN' => BlockReason.unknown,
-    'UNSPECIFIED' => BlockReason.unspecified,
+    'BLOCK_REASON_UNSPECIFIED' => BlockReason.unspecified,
     'SAFETY' => BlockReason.safety,
     'OTHER' => BlockReason.other,
     _ => throw FormatException('Unhandled BlockReason format', jsonObject),


### PR DESCRIPTION
The REST API discovery document lists `BLOCK_REASON_UNSPECIFIED` as the
enum value. There is no `UNKNOWN` listed.
