### PR TITLE
Remove incorrect error handling in sample

### DIFF
--- a/samples/dart/bin/advanced_text_and_image.dart
+++ b/samples/dart/bin/advanced_text_and_image.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:google_generative_ai/google_generative_ai.dart';
 
@@ -33,16 +32,10 @@ void main() async {
       'What do you see? Use lists. Start with a headline for each image.';
   print('Prompt: $prompt');
 
-  late final Uint8List catBytes, sconeBytes;
-  try {
-    (catBytes, sconeBytes) = await (
-      readResource('cat.jpg'),
-      readResource('scones.jpg'),
-    ).wait;
-  } on ParallelWaitError catch (e) {
-    print('Error:');
-    e.errors.forEach(print);
-  }
+  final (catBytes, sconeBytes) = await (
+    readResource('cat.jpg'),
+    readResource('scones.jpg'),
+  ).wait;
   final content = [
     Content.multi([
       TextPart(prompt),

--- a/samples/dart/bin/simple_text_and_image.dart
+++ b/samples/dart/bin/simple_text_and_image.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:google_generative_ai/google_generative_ai.dart';
 
@@ -29,8 +28,7 @@ void main() async {
   final prompt = 'What do you see?';
   print('Prompt: $prompt');
 
-  late final Uint8List catBytes, sconeBytes;
-  (catBytes, sconeBytes) = await (
+  final (catBytes, sconeBytes) = await (
     readResource('cat.jpg'),
     readResource('scones.jpg'),
   ).wait;


### PR DESCRIPTION
The usage of `ParallelWaitError.errors` was incorrect - it is not an
iterable.
Remove the error handling, since it is not the interesting part of the
sample and its more noise than is useful.

Inline the variable declaration in both places where Record.wait is
used. In both cases the `late` was already unnecessary.
