### PR TITLE
Cleanup in sample code

### DIFF
--- a/samples/dart/bin/advanced_chat.dart
+++ b/samples/dart/bin/advanced_chat.dart
@@ -19,7 +19,7 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 Future<void> main() async {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
-    print('No \$GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(
@@ -32,7 +32,7 @@ Future<void> main() async {
   ]);
   var message = 'How many paws are in my house?';
   print('Message: $message');
-  var content = Content.text('How many paws are in my house?');
+  var content = Content.text(message);
   var CountTokensResponse(:totalTokens) =
       await model.countTokens([...chat.history, content]);
   print('Token count: $totalTokens');

--- a/samples/dart/bin/advanced_text.dart
+++ b/samples/dart/bin/advanced_text.dart
@@ -19,7 +19,7 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 void main() async {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
-    print('No \$GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(

--- a/samples/dart/bin/advanced_text_and_image.dart
+++ b/samples/dart/bin/advanced_text_and_image.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:google_generative_ai/google_generative_ai.dart';
 
@@ -22,7 +21,7 @@ import 'util/resource.dart';
 void main() async {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
-    print('No \$GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(
@@ -33,16 +32,10 @@ void main() async {
       'What do you see? Use lists. Start with a headline for each image.';
   print('Prompt: $prompt');
 
-  late final Uint8List catBytes, sconeBytes;
-  try {
-    (catBytes, sconeBytes) = await (
-      readResource('cat.jpg'),
-      readResource('scones.jpg'),
-    ).wait;
-  } on ParallelWaitError catch (e) {
-    print('Error:');
-    e.errors.forEach(print);
-  }
+  final (catBytes, sconeBytes) = await (
+    readResource('cat.jpg'),
+    readResource('scones.jpg'),
+  ).wait;
   final content = [
     Content.multi([
       TextPart(prompt),

--- a/samples/dart/bin/simple_chat.dart
+++ b/samples/dart/bin/simple_chat.dart
@@ -19,7 +19,7 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 Future<void> main() async {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
-    print('No \$GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);

--- a/samples/dart/bin/simple_config.dart
+++ b/samples/dart/bin/simple_config.dart
@@ -24,7 +24,7 @@ Future<void> generate(GenerationConfig? generationConfig, String apiKey) async {
   print('Prompt: $prompt');
   final content = [Content.text(prompt)];
 
-  print('Options: ${jsonEncode(generationConfig)}');
+  print('Options: ${jsonEncode(generationConfig?.toJson())}');
 
   final response = await model.generateContent(content);
   print('Response:');
@@ -34,7 +34,7 @@ Future<void> generate(GenerationConfig? generationConfig, String apiKey) async {
 Future<void> main() async {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
-    print('No \$GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
   await generate(null, apiKey);

--- a/samples/dart/bin/simple_embedding.dart
+++ b/samples/dart/bin/simple_embedding.dart
@@ -19,7 +19,7 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 void main() async {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
-    print('No \$GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(model: 'embedding-001', apiKey: apiKey);

--- a/samples/dart/bin/simple_text.dart
+++ b/samples/dart/bin/simple_text.dart
@@ -19,7 +19,7 @@ import 'package:google_generative_ai/google_generative_ai.dart';
 void main() async {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
-    print('No \$GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);

--- a/samples/dart/bin/simple_text_and_image.dart
+++ b/samples/dart/bin/simple_text_and_image.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:google_generative_ai/google_generative_ai.dart';
 
@@ -22,15 +21,14 @@ import 'util/resource.dart';
 void main() async {
   final apiKey = Platform.environment['GOOGLE_API_KEY'];
   if (apiKey == null) {
-    print('No \$GOOGLE_API_KEY environment variable');
+    stderr.writeln(r'No $GOOGLE_API_KEY environment variable');
     exit(1);
   }
   final model = GenerativeModel(model: 'gemini-pro-vision', apiKey: apiKey);
   final prompt = 'What do you see?';
   print('Prompt: $prompt');
 
-  late final Uint8List catBytes, sconeBytes;
-  (catBytes, sconeBytes) = await (
+  final (catBytes, sconeBytes) = await (
     readResource('cat.jpg'),
     readResource('scones.jpg'),
   ).wait;

--- a/samples/dart/bin/util/resource.dart
+++ b/samples/dart/bin/util/resource.dart
@@ -17,7 +17,16 @@ import 'dart:typed_data';
 
 import 'package:path/path.dart' as path;
 
+/// Reads a file from the `resources/` directory of this Pub package root
+/// directory.
+///
+/// The [name] is the entire file name, including extension.
+///
+/// Assumes the script is run from the `bin/` directory or another immediate
+/// subdirectory of the package root directory.
 Future<Uint8List> readResource(String name) {
-  final uri = Platform.script.resolve(path.join('..', 'resources', name));
-  return File.fromUri(uri).readAsBytes();
+  return File(path.join(_resourceDirectory.path, name)).readAsBytes();
 }
+
+final _resourceDirectory =
+    Directory.fromUri(Platform.script.resolve('../resources/'));


### PR DESCRIPTION
Remove incorrect usage of `ParallelWaitError.errors` - it is not an
iterable. The error handling is not the interesting part of the sample
and it's more noise than is useful, so remove it. Inline the variable
declaration in both places where Record.wait is used. In both cases the
`late` was already unnecessary.

Apply fixes from https://github.com/google/generative-ai-dart/pull/28
- Write errors to `stederr`.
- Reference `message` var instead of repeat the string.
- Fix usage of Uri path to resolve resource files.
