### PR TITLE
Refactor HttpApiClient

### DIFF
--- a/pkgs/google_generative_ai/lib/src/client.dart
+++ b/pkgs/google_generative_ai/lib/src/client.dart
@@ -46,7 +46,7 @@ final class HttpApiClient implements ApiClient {
       headers: {
         'x-goog-api-key': _apiKey,
         'x-goog-api-client': clientName,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
       body: _utf8Json.encode(body),
     );


### PR DESCRIPTION
Taken from https://github.com/google/generative-ai-dart/pull/28

- Fuse the utf8 and json codecs instead of applying them separately.
- Refactor to `async*` over manually using a `StreamController`.
