### PR TITLE
Run tests on web

### DIFF
--- a/.github/workflows/google_generative_ai.yml
+++ b/.github/workflows/google_generative_ai.yml
@@ -44,3 +44,6 @@ jobs:
 
       - run: dart test
         if: ${{matrix.run-tests}}
+
+      - run: dart test --platform chrome
+        if: ${{matrix.run-tests}}


### PR DESCRIPTION
For now only uses dart2js since tests are only ran on stable.