### PR TITLE
Make `sendRequestStream` eager and caching.

### DIFF
--- a/pkgs/google_generative_ai/lib/src/chat.dart
+++ b/pkgs/google_generative_ai/lib/src/chat.dart
@@ -100,8 +100,9 @@ final class ChatSession {
     final controller = StreamController<GenerateContentResponse>(sync: true);
     _mutex.acquire().then((lock) async {
       try {
-        final responses =
-            _generateContentStream(_history.followedBy([message]));
+        final responses = _generateContentStream(_history.followedBy([message]),
+            safetySettings: _safetySettings,
+            generationConfig: _generationConfig);
         final content = <Content>[];
         await for (final response in responses) {
           if (response.candidates case [final candidate, ...]) {


### PR DESCRIPTION
The `sendRequestStream` function now sends the request eagerly, as soon as prior requests are done, whether someone is listening to the returned stream or not.
The stream will cache responses until listened to.

This should ensure that nobody listening on the stream won't affect the ordering of requests, or block later requests.

It was a remarkably easy change.