### PR TITLE
Fix a bug where the developer's `Client` was not used in unary requests

### DIFF
--- a/pkgs/google_generative_ai/lib/src/client.dart
+++ b/pkgs/google_generative_ai/lib/src/client.dart
@@ -36,12 +36,12 @@ final class HttpApiClient implements ApiClient {
 
   HttpApiClient({required String apiKey, http.Client? httpClient})
       : _apiKey = apiKey,
-        _httpClient = httpClient ?? http.Client();
+        _httpClient = httpClient;
 
   @override
   Future<Map<String, Object?>> makeRequest(
       Uri uri, Map<String, Object?> body) async {
-    final response = await http.post(
+    final response = await (_httpClient?.post ?? http.post)(
       uri,
       headers: {
         'x-goog-api-key': _apiKey,

--- a/pkgs/google_generative_ai/test/http_api_client_test.dart
+++ b/pkgs/google_generative_ai/test/http_api_client_test.dart
@@ -23,7 +23,7 @@ import 'utils/matchers.dart';
 
 void main() {
   group('HttpApiClient', () {
-    test('can make unary request', () async {
+    test('can make unary request with default client', () async {
       final url = Uri.parse('https://someurl.com');
       final body = {'some': 'body'};
       final apiKey = 'apiKey';
@@ -48,7 +48,30 @@ void main() {
               }));
     });
 
-    test('can make streaming request', () async {
+    test('can make unary request with custom client', () async {
+      final url = Uri.parse('https://someurl.com');
+      final body = {'some': 'body'};
+      final apiKey = 'apiKey';
+      final expectedResponse = {'result': 'OK'};
+      final httpClient = MockClient((request) async {
+        expect(
+            request,
+            matchesRequest(http.Request('POST', url)
+              ..headers.addAll({
+                'x-goog-api-key': apiKey,
+                'x-goog-api-client': clientName,
+                'Content-Type': 'application/json'
+              })
+              ..bodyBytes = utf8.encode(jsonEncode(body))));
+        return http.Response.bytes(
+            utf8.encode(jsonEncode(expectedResponse)), 200);
+      });
+      final client = HttpApiClient(apiKey: apiKey, httpClient: httpClient);
+      final response = await client.makeRequest(url, body);
+      expect(response, expectedResponse);
+    });
+
+    test('can make streaming request with default client', () async {
       final url = Uri.parse('https://someurl.com');
       final streamingUrl = Uri.parse('https://someurl.com?alt=sse');
       final body = {'some': 'body'};
@@ -79,6 +102,37 @@ void main() {
                         .map((r) => utf8.encode('data: ${jsonEncode(r)}\n')),
                     200);
               }));
+    });
+
+    test('can make streaming request with custom client', () async {
+      final url = Uri.parse('https://someurl.com');
+      final streamingUrl = Uri.parse('https://someurl.com?alt=sse');
+      final body = {'some': 'body'};
+      final apiKey = 'apiKey';
+      final expectedResponses = [
+        {'first': 'OK'},
+        {'second': 'OK'}
+      ];
+      final httpClient = MockClient.streaming((request, requestStream) async {
+        expect(
+            request,
+            matchesBaseRequest(http.Request('POST', streamingUrl)
+              ..headers.addAll({
+                'x-goog-api-key': apiKey,
+                'x-goog-api-client': clientName,
+                'Content-Type': 'application/json'
+              })));
+        expect(requestStream,
+            emitsInOrder([utf8.encode(jsonEncode(body)), emitsDone]));
+        return http.StreamedResponse(
+            Stream.fromIterable(expectedResponses)
+                .map((r) => utf8.encode('data: ${jsonEncode(r)}\n')),
+            200);
+      });
+      final client = HttpApiClient(apiKey: apiKey, httpClient: httpClient);
+      final response = client.streamRequest(url, body);
+      await expectLater(
+          response, emitsInOrder([...expectedResponses, emitsDone]));
     });
   });
 }


### PR DESCRIPTION
1. Removed the rogue `Client` creation i.e. `_httpClient = httpClient ?? http.Client();`
2. Fixed a bug where `makeRequest` did not use the developers `httpClient`
3. Added tests for the cases where the developer providers their own `httpClient`