### PR TITLE
Makes the error text selectable and checks for API key

### DIFF
--- a/samples/flutter_app/lib/main.dart
+++ b/samples/flutter_app/lib/main.dart
@@ -74,13 +74,15 @@ class _ChatWidgetState extends State<ChatWidget> {
   final TextEditingController _textController = TextEditingController();
   final FocusNode _textFieldFocus = FocusNode();
   bool _loading = false;
+  late final String apiKey;
 
   @override
   void initState() {
     super.initState();
+    apiKey = const String.fromEnvironment('API_KEY');
     _model = GenerativeModel(
       model: 'gemini-pro',
-      apiKey: const String.fromEnvironment('API_KEY'),
+      apiKey: apiKey,
     );
     _chat = _model.startChat();
   }
@@ -127,21 +129,27 @@ class _ChatWidgetState extends State<ChatWidget> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Expanded(
-            child: ListView.builder(
-              controller: _scrollController,
-              itemBuilder: (context, idx) {
-                var content = _chat.history.toList()[idx];
-                var text = content.parts
-                    .whereType<TextPart>()
-                    .map<String>((e) => e.text)
-                    .join('');
-                return MessageWidget(
-                  text: text,
-                  isFromUser: content.role == 'user',
-                );
-              },
-              itemCount: _chat.history.length,
-            ),
+            child: apiKey.isNotEmpty
+                ? ListView.builder(
+                    controller: _scrollController,
+                    itemBuilder: (context, idx) {
+                      var content = _chat.history.toList()[idx];
+                      var text = content.parts
+                          .whereType<TextPart>()
+                          .map<String>((e) => e.text)
+                          .join('');
+                      return MessageWidget(
+                        text: text,
+                        isFromUser: content.role == 'user',
+                      );
+                    },
+                    itemCount: _chat.history.length,
+                  )
+                : ListView(
+                    children: const [
+                      Text('No API key found. Please provide an API Key.'),
+                    ],
+                  ),
           ),
           Padding(
             padding: const EdgeInsets.symmetric(
@@ -225,7 +233,7 @@ class _ChatWidgetState extends State<ChatWidget> {
         return AlertDialog(
           title: const Text('Something went wrong'),
           content: SingleChildScrollView(
-            child: Text(message),
+            child: SelectableText(message),
           ),
           actions: [
             TextButton(

--- a/samples/flutter_app/lib/main.dart
+++ b/samples/flutter_app/lib/main.dart
@@ -79,10 +79,9 @@ class _ChatWidgetState extends State<ChatWidget> {
   @override
   void initState() {
     super.initState();
-    apiKey = const String.fromEnvironment('API_KEY');
     _model = GenerativeModel(
       model: 'gemini-pro',
-      apiKey: apiKey,
+      apiKey: _apiKey,
     );
     _chat = _model.startChat();
   }
@@ -129,7 +128,7 @@ class _ChatWidgetState extends State<ChatWidget> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Expanded(
-            child: apiKey.isNotEmpty
+            child: _apiKey.isNotEmpty
                 ? ListView.builder(
                     controller: _scrollController,
                     itemBuilder: (context, idx) {

--- a/samples/flutter_app/lib/main.dart
+++ b/samples/flutter_app/lib/main.dart
@@ -74,7 +74,7 @@ class _ChatWidgetState extends State<ChatWidget> {
   final TextEditingController _textController = TextEditingController();
   final FocusNode _textFieldFocus = FocusNode();
   bool _loading = false;
-  late final String apiKey;
+  static const _apiKey = const String.fromEnvironment('API_KEY');
 
   @override
   void initState() {

--- a/samples/flutter_app/lib/main.dart
+++ b/samples/flutter_app/lib/main.dart
@@ -74,7 +74,7 @@ class _ChatWidgetState extends State<ChatWidget> {
   final TextEditingController _textController = TextEditingController();
   final FocusNode _textFieldFocus = FocusNode();
   bool _loading = false;
-  static const _apiKey = const String.fromEnvironment('API_KEY');
+  static const _apiKey = String.fromEnvironment('API_KEY');
 
   @override
   void initState() {

--- a/samples/flutter_app/lib/main.dart
+++ b/samples/flutter_app/lib/main.dart
@@ -278,7 +278,10 @@ class MessageWidget extends StatelessWidget {
               horizontal: 20,
             ),
             margin: const EdgeInsets.only(bottom: 8),
-            child: MarkdownBody(data: text),
+            child: MarkdownBody(
+              selectable: true,
+              data: text,
+            ),
           ),
         ),
       ],

--- a/samples/flutter_app/macos/Runner/DebugProfile.entitlements
+++ b/samples/flutter_app/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+<true/>
 </dict>
 </plist>

--- a/samples/flutter_app/macos/Runner/Release.entitlements
+++ b/samples/flutter_app/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+<true/>
 </dict>
 </plist>


### PR DESCRIPTION
The error message when there's no API key isn't super helpful: 
<img width="673" alt="image (8)" src="https://github.com/google/generative-ai-dart/assets/12416400/f93ee96b-7634-4c0c-8853-04fe6159d56d">
<img width="1458" alt="image (7)" src="https://github.com/google/generative-ai-dart/assets/12416400/2e997e9c-f2b0-4ae3-8ba0-88f230786144">

After:
<img width="802" alt="Screenshot 2024-02-15 at 7 57 25 AM" src="https://github.com/google/generative-ai-dart/assets/12416400/940b87f1-5d4d-4be5-877f-cb4553e3c812">
<img width="801" alt="Screenshot 2024-02-15 at 7 57 40 AM" src="https://github.com/google/generative-ai-dart/assets/12416400/ebc52e06-f5fe-4616-a870-87bbf20fa628">
