### PR TITLE
Add link to ai.google.dev docs

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1-wip
+
+- Add link to ai.google.dev docs.
+
 ## 0.2.0
 
 - **Breaking** `HarmCategory.unknown` renamed to `unspecified`. Removed unused

--- a/pkgs/google_generative_ai/README.md
+++ b/pkgs/google_generative_ai/README.md
@@ -59,6 +59,13 @@ void main() async {
 See additional examples at
 [samples/](https://github.com/google/generative-ai-dart/tree/main/samples).
 
+For detailed instructions, you can find a quickstart for the Google AI Dart SDK
+in the Google documentation: http://ai.google.dev/tutorials/dart_quickstart.
+This quickstart describes how to add your API key and the SDK to your app,
+initialize the model, and then call the API to access the model. It also
+describes some additional use cases and features, like streaming, embedding,
+counting tokens, and controlling responses.
+
 ## Additional documentation
 
 You can find additional documentation for the Google AI SDKs and the Gemini

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_generative_ai
-version: 0.2.0
+version: 0.2.1-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).


### PR DESCRIPTION
The docs are now published and the link is available.
