### PR TITLE
Fix CitationSource parsing

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Fix an issue parsing `generateContent()` responses that do not include content
   (this can occur for some `finishReason`s).
+- Fix an issue parsing `generateContent()` responses that include citation
+  sources with unpopulated fields
 - Add link to ai.google.dev docs.
 
 ## 0.2.0

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -579,14 +579,16 @@ CitationMetadata _parseCitationMetadata(Object? jsonObject) {
 }
 
 CitationSource _parseCitationSource(Object? jsonObject) {
-  return switch (jsonObject) {
-    {
-      'startIndex': final int startIndex,
-      'endIndex': final int endIndex,
-      'uri': final String uri,
-      'license': final String license,
-    } =>
-      CitationSource(startIndex, endIndex, Uri.parse(uri), license),
-    _ => throw FormatException('Unhandled CitationSource format', jsonObject),
-  };
+  if (jsonObject is! Map) {
+    throw FormatException('Unhandled CitationSource format', jsonObject);
+  }
+
+  final uriString = jsonObject['uri'] as String?;
+
+  return CitationSource(
+    jsonObject['startIndex'] as int?,
+    jsonObject['endIndex'] as int?,
+    uriString != null ? Uri.parse(uriString) : null,
+    jsonObject['license'] as String?,
+  );
 }

--- a/pkgs/google_generative_ai/test/response_parsing_test.dart
+++ b/pkgs/google_generative_ai/test/response_parsing_test.dart
@@ -247,7 +247,16 @@ void main() {
             "endIndex": 1026,
             "uri": "https://example.com/",
             "license": ""
-          }
+          },
+          {
+            "startIndex": 899,
+            "endIndex": 1026
+          },
+          {
+            "uri": "https://example.com/",
+            "license": ""
+          },
+          {}
         ]
       }
     }


### PR DESCRIPTION
Resolves #75 

There are two questions regarding this solution. I will change it if you think it should be different then I've implemented.
1. Do we want to return `CitationSource` with only nulls? It is technically a valid response from the API but doesn't make much sense.
2. What if uri parsing fails? Do we want to be more lenient and return `null`? Do we want to throw `FormatException`? Or do we expect that it will always be a valid URI if provided and leave it as is?