### PR TITLE
rev to 0.2.1

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.1-wip
+## 0.2.1
 
 - Fix an issue parsing `generateContent()` responses that do not include content
   (this can occur for some `finishReason`s).

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_generative_ai
-version: 0.2.1-wip
+version: 0.2.1
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).


### PR DESCRIPTION
- rev to `0.2.1` in prep for publishing

This captures the two parsing fixes in #76 and #84.