### PR TITLE
Add compatibility with older Dart SDK back to 3.0

### DIFF
--- a/.github/workflows/google_generative_ai.yml
+++ b/.github/workflows/google_generative_ai.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ['3.2', stable, dev]
+        sdk: ['3.0', stable, dev]
         include:
           - sdk: stable
             run-tests: true

--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.2-wip
+## 0.2.2
 
 - Remove usage of new SDK features - support older SDKs 3.0 and above.
 

--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2-wip
+
+- Remove usage of new SDK features - support older SDKs 3.0 and above.
+
 ## 0.2.1
 
 - Fix an issue parsing `generateContent()` responses that do not include content

--- a/pkgs/google_generative_ai/lib/src/chat.dart
+++ b/pkgs/google_generative_ai/lib/src/chat.dart
@@ -139,7 +139,6 @@ final class ChatSession {
       if (textBuffer.isEmpty) return;
       // TODO: When updating min SDK remove workaround.
       // if (previousText case final singleText?) {
-      //   parts.add(singleText);
       final singleText = previousText;
       if (singleText != null) {
         parts.add(singleText);

--- a/pkgs/google_generative_ai/lib/src/chat.dart
+++ b/pkgs/google_generative_ai/lib/src/chat.dart
@@ -137,7 +137,11 @@ final class ChatSession {
     final parts = <Part>[];
     void addBufferedText() {
       if (textBuffer.isEmpty) return;
-      if (previousText case final singleText?) {
+      // TODO: When updating min SDK remove workaround.
+      // if (previousText case final singleText?) {
+      //   parts.add(singleText);
+      final singleText = previousText;
+      if (singleText != null) {
         parts.add(singleText);
         previousText = null;
       } else {

--- a/pkgs/google_generative_ai/lib/src/client.dart
+++ b/pkgs/google_generative_ai/lib/src/client.dart
@@ -62,9 +62,11 @@ final class HttpApiClient implements ApiClient {
       ..headers['x-goog-api-key'] = _apiKey
       ..headers['x-goog-api-client'] = clientName
       ..headers['Content-Type'] = 'application/json';
-    final response = _httpClient == null
+    // TODO: When updating min SDK remove workaround.
+    final httpClient = _httpClient;
+    final response = httpClient == null
         ? await request.send()
-        : await _httpClient.send(request);
+        : await httpClient.send(request);
     final lines =
         response.stream.toStringStream().transform(const LineSplitter());
     await for (final line in lines) {

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_generative_ai
-version: 0.2.2-wip
+version: 0.2.2
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,12 +1,12 @@
 name: google_generative_ai
-version: 0.2.1
+version: 0.2.2-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).
 repository: https://github.com/google/generative-ai-dart/tree/main/pkgs/google_generative_ai
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.0.0
 
 dependencies:
   http: ^1.1.0

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -18,9 +18,13 @@ import 'package:matcher/matcher.dart';
 
 Matcher matchesPart(Part part) => switch (part) {
       TextPart(text: final text) =>
+        // TODO: When updating min SDK remove ignore.
+        // ignore: unused_result, implementation bug
         isA<TextPart>().having((p) => p.text, 'text', text),
       DataPart(mimeType: final mimeType, bytes: final bytes) => isA<DataPart>()
           .having((p) => p.mimeType, 'mimeType', mimeType)
+          // TODO: When updating min SDK remove ignore.
+          // ignore: unused_result, implementation bug
           .having((p) => p.bytes, 'bytes', bytes),
     };
 

--- a/samples/dart/pubspec.yaml
+++ b/samples/dart/pubspec.yaml
@@ -3,7 +3,7 @@ name: generative_ai_samples
 publish_to: none
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.0.0
 
 dependencies:
   path: ^1.9.0


### PR DESCRIPTION
Add workarounds for changes in inference which result in static errors.

Add ignores for since-fixed false positive diagnostics.

Test on a 3.0 SDK on CI.
