### PR TITLE
Delete .github/ISSUE_TEMPLATE/google_generative_ai.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/google_generative_ai.md
+++ b/.github/ISSUE_TEMPLATE/google_generative_ai.md
@@ -1,5 +1,0 @@
----
-name: "package:google_generative_ai"
-about: "Create a bug or file a feature request against package:google_generative_ai."
-labels: "package:google_generative_ai"
----


### PR DESCRIPTION
- delete .github/ISSUE_TEMPLATE/google_generative_ai.md

I assume that this labelling - assigning `package:google_generative_ai` - doesn't line up w/ the new triage process.
