### PR TITLE
expose the listModels call

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.2.3-wip
+## 0.3.0-wip
 
 - Update the package version that is sent with the HTTP client name.
 - Throw more actionable error objects than `FormatException` for errors. Errors
   were previously only correctly parsed in `generateContent` calls.
+- Expose a way to list available models - `GenerativeModel.listModels`.
 
 ## 0.2.2
 

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -52,6 +52,8 @@ export 'src/api.dart'
         HarmBlockThreshold,
         HarmCategory,
         HarmProbability,
+        ListModelsResponse,
+        Model,
         PromptFeedback,
         SafetyRating,
         SafetySetting,

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -88,6 +88,34 @@ final class EmbedContentResponse {
   EmbedContentResponse(this.embedding);
 }
 
+/// Response from [GenerativeModel.listModels] containing a paginated list of
+/// Models.
+final class ListModelsResponse {
+  /// The returned Models.
+  final List<Model> models;
+
+  /// A token, which can be sent as pageToken to retrieve the next page.
+  ///
+  /// If this field is omitted, there are no more pages.
+  final String? nextPageToken;
+
+  ListModelsResponse({
+    required this.models,
+    this.nextPageToken,
+  });
+
+  static ListModelsResponse parseJson(Map<String, Object?> json) {
+    if (json.containsKey('error')) throw parseError(json['error']!);
+
+    return ListModelsResponse(
+      models: (json['models'] as List).map((item) {
+        return Model.parseJson(item as Map<String, Object?>);
+      }).toList(),
+      nextPageToken: json['nextPageToken'] as String?,
+    );
+  }
+}
+
 /// An embedding, as defined by a list of values.
 final class ContentEmbedding {
   /// The embedding values.
@@ -435,6 +463,98 @@ final class GenerationConfig {
         if (topP case final topP?) 'topP': topP,
         if (topK case final topK?) 'topK': topK,
       };
+}
+
+/// Information about a Generative Language Model.
+class Model {
+  /// The resource name of the Model.
+  ///
+  /// Format: `models/{model}` with a `{model}` naming convention of:
+  ///
+  ///   "{baseModelId}-{version}"
+  ///
+  /// Examples:
+  ///
+  /// - `models/chat-bison-001`
+  final String name;
+
+  /// The version number of the model.
+  ///
+  /// This represents the major version.
+  final String version;
+
+  /// The human-readable name of the model. E.g. "Chat Bison".
+  ///
+  /// The name can be up to 128 characters long and can consist of any UTF-8
+  /// characters.
+  final String displayName;
+
+  /// A short description of the model.
+  final String description;
+
+  /// Maximum number of input tokens allowed for this model.
+  final int inputTokenLimit;
+
+  /// Maximum number of output tokens available for this model.
+  final int outputTokenLimit;
+
+  /// The model's supported generation methods.
+  ///
+  /// The method names are defined as Pascal case strings, such as
+  /// `generateMessage` which correspond to API methods.
+  final List<String> supportedGenerationMethods;
+
+  /// Controls the randomness of the output.
+  ///
+  /// Values can range over `[0.0,1.0]`, inclusive. A value closer to 1.0 will
+  /// produce responses that are more varied, while a value closer to 0.0 will
+  /// typically result in less surprising responses from the model. This value
+  /// specifies default to be used by the backend while making the call to the
+  /// model.
+  final double? temperature;
+
+  /// For Nucleus sampling.
+  ///
+  /// Nucleus sampling considers the smallest set of tokens whose probability
+  /// sum is at least topP. This value specifies default to be used by the
+  /// backend while making the call to the model.
+  final int? topP;
+
+  /// For Top-k sampling.
+  ///
+  /// Top-k sampling considers the set of topK most probable tokens. This value
+  /// specifies default to be used by the backend while making the call to the
+  /// model.
+  final int? topK;
+
+  Model({
+    required this.name,
+    required this.version,
+    required this.displayName,
+    required this.description,
+    required this.inputTokenLimit,
+    required this.outputTokenLimit,
+    required this.supportedGenerationMethods,
+    this.temperature,
+    this.topP,
+    this.topK,
+  });
+
+  static Model parseJson(Map<String, Object?> json) {
+    return Model(
+      name: json['name'] as String,
+      version: json['version'] as String,
+      displayName: json['displayName'] as String,
+      description: json['description'] as String,
+      inputTokenLimit: json['inputTokenLimit'] as int,
+      outputTokenLimit: json['outputTokenLimit'] as int,
+      supportedGenerationMethods:
+          (json['supportedGenerationMethods'] as List).cast(),
+      temperature: json['temperature'] as double?,
+      topP: json['topP'] as int?,
+      topK: json['topK'] as int?,
+    );
+  }
 }
 
 /// Type of task for which the embedding will be used.

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.2.3-wip';
+const packageVersion = '0.3.0-wip';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_generative_ai
-version: 0.2.3-wip
+version: 0.3.0-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -406,5 +406,55 @@ void main() {
                 EmbedContentResponse(ContentEmbedding([0.1, 0.2, 0.3]))));
       });
     });
+
+    test('listModels', () async {
+      final apiKey = 'apiKey';
+      final client = StubClient();
+      client.stubGet(
+        Uri.parse('https://generativelanguage.googleapis.com/v1/models'),
+        null,
+        {
+          'models': [
+            {
+              'name': 'models/gemini-1.0-pro',
+              'version': '001',
+              'displayName': 'Gemini 1.0 Pro',
+              'description':
+                  'The best model for scaling across a wide range of tasks',
+              'inputTokenLimit': 30720,
+              'outputTokenLimit': 2048,
+              'supportedGenerationMethods': ['generateContent', 'countTokens'],
+              'temperature': 0.9,
+              'topP': 1,
+              'topK': 1
+            },
+            {
+              'name': 'models/embedding-001',
+              'version': '001',
+              'displayName': 'Embedding 001',
+              'description': 'Obtain a distributed representation of a text.',
+              'inputTokenLimit': 2048,
+              'outputTokenLimit': 1,
+              'supportedGenerationMethods': ['embedContent']
+            }
+          ]
+        },
+      );
+      final response =
+          await GenerativeModel.listModels(apiKey: apiKey, apiClient: client);
+      expect(response.models, hasLength(2));
+
+      var model = response.models[0];
+      expect(model.name, 'models/gemini-1.0-pro');
+      expect(model.version, isNotEmpty);
+      expect(model.displayName, isNotEmpty);
+      expect(model.description, isNotEmpty);
+
+      model = response.models[1];
+      expect(model.name, 'models/embedding-001');
+      expect(model.version, isNotEmpty);
+      expect(model.displayName, isNotEmpty);
+      expect(model.description, isNotEmpty);
+    });
   });
 }

--- a/pkgs/google_generative_ai/test/http_api_client_test.dart
+++ b/pkgs/google_generative_ai/test/http_api_client_test.dart
@@ -71,6 +71,34 @@ void main() {
       expect(response, expectedResponse);
     });
 
+    test('can make unary GET request', () async {
+      final url = Uri.parse('https://someurl.com?some=param');
+      final params = {'some': 'param'};
+      final apiKey = 'apiKey';
+      final expectedResponse = {'result': 'OK'};
+      await http.runWithClient(
+        () async {
+          final client = HttpApiClient(apiKey: apiKey);
+          final response =
+              await client.makeGetRequest(url, queryParameters: params);
+          expect(response, expectedResponse);
+        },
+        () => MockClient((request) async {
+          expect(
+            request,
+            matchesRequest(http.Request('GET', url)
+              ..headers.addAll({
+                'x-goog-api-key': apiKey,
+                'x-goog-api-client': clientName,
+                'Content-Type': 'application/json'
+              })),
+          );
+          return http.Response.bytes(
+              utf8.encode(jsonEncode(expectedResponse)), 200);
+        }),
+      );
+    });
+
     test('can make streaming request with default client', () async {
       final url = Uri.parse('https://someurl.com');
       final streamingUrl = Uri.parse('https://someurl.com?alt=sse');

--- a/pkgs/google_generative_ai/test/utils/stub_client.dart
+++ b/pkgs/google_generative_ai/test/utils/stub_client.dart
@@ -27,6 +27,11 @@ final class StubClient implements ApiClient {
 
   void stub(Uri uri, Map<String, Object?> body, Map<String, Object?> result) =>
       _requests[{'_hack_uri': uri, ...body}] = result;
+
+  void stubGet(Uri uri, Map<String, Object?>? queryParameters,
+          Map<String, Object?> result) =>
+      _requests[{'_hack_uri': uri, ...(queryParameters ?? {})}] = result;
+
   void stubStream(Uri uri, Map<String, Object?> body,
           Iterable<Map<String, Object?>> result) =>
       _streamRequests[{'_hack_uri': uri, ...body}] = result;
@@ -37,6 +42,14 @@ final class StubClient implements ApiClient {
       Future.value(_requests.remove({'_hack_uri': uri, ...body}) ??
           (throw StateError(
               'Missing stub for request to $uri with body $body')));
+
+  @override
+  Future<Map<String, Object?>> makeGetRequest(Uri uri,
+          {Map<String, dynamic>? queryParameters}) =>
+      Future.value(_requests
+              .remove({'_hack_uri': uri, ...(queryParameters ?? {})}) ??
+          (throw StateError(
+              'Missing stub for request to $uri with params $queryParameters')));
 
   @override
   Stream<Map<String, Object?>> streamRequest(


### PR DESCRIPTION
- expose the `listModels` call
- fix https://github.com/google/generative-ai-dart/issues/93
- rev to a new major version as this is an api addition

This exposes model.listModels as a static method on `GenerativeModel`. The user needs to explicitly pass the api Key to this static method (instead of passing it into the GenerativeModel ctor as for the other calls).

I expose `ApiClient? apiClient` as a param as well for testability; this does make for a kludgy method sig (w/ params `String apiKey`, `int? pageSize`, `String? pageToken`, `http.Client? httpClient`, and `ApiClient? apiClient`).
