### PR TITLE
Add support for tuned models

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update the package version that is sent with the HTTP client name.
 - Throw more actionable error objects than `FormatException` for errors. Errors
   were previously only correctly parsed in `generateContent` calls.
+- Add support for tuned models.
 
 ## 0.2.2
 

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -39,8 +39,8 @@ enum Task {
 /// Allows generating content, creating embeddings, and counting the number of
 /// tokens in a piece of content.
 final class GenerativeModel {
-  /// The full model identifier split into a prefix ("models" or "tunedModels")
-  /// and the model name.
+  /// The full model code split into a prefix ("models" or "tunedModels") and
+  /// the model name.
   final ({String prefix, String name}) _model;
   final List<SafetySetting> _safetySettings;
   final GenerationConfig? _generationConfig;
@@ -91,6 +91,10 @@ final class GenerativeModel {
         _generationConfig = generationConfig,
         _client = client;
 
+  /// Returns the model code for a user friendly model name.
+  ///
+  /// If the model name is already a model code (contains a `/`), use the parts
+  /// directly. Otherwise, return a `models/` model code.
   static ({String prefix, String name}) _normalizeModelName(String modelName) {
     if (!modelName.contains('/')) return (prefix: 'models', name: modelName);
     final parts = modelName.split('/');

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -69,6 +69,45 @@ void main() {
           ], null)));
     });
 
+    test('allows specifying a tuned model', () async {
+      final (client, model) = createModel('tunedModels/$defaultModelName');
+      final prompt = 'Some prompt';
+      final result = 'Some response';
+      client.stub(
+        Uri.parse('https://generativelanguage.googleapis.com/v1/'
+            'tunedModels/some-model:generateContent'),
+        {
+          'contents': [
+            {
+              'role': 'user',
+              'parts': [
+                {'text': prompt}
+              ]
+            }
+          ]
+        },
+        {
+          'candidates': [
+            {
+              'content': {
+                'role': 'model',
+                'parts': [
+                  {'text': result}
+                ]
+              }
+            }
+          ]
+        },
+      );
+      final response = await model.generateContent([Content.text(prompt)]);
+      expect(
+          response,
+          matchesGenerateContentResponse(GenerateContentResponse([
+            Candidate(
+                Content('model', [TextPart(result)]), null, null, null, null),
+          ], null)));
+    });
+
     group('generate unary content', () {
       test('can make successful request', () async {
         final (client, model) = createModel();


### PR DESCRIPTION
Store the model code as a record with a prefix and name to allow
overriding the default `models/` path segment with `tunedModels/`.
