### PR TITLE
Add batchEmbedContents support

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Throw more actionable error objects than `FormatException` for errors. Errors
   were previously only correctly parsed in `generateContent` calls.
 - Add support for tuned models.
+- Add support for `batchEmbedContents` calls.
 
 ## 0.2.2
 

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -39,12 +39,14 @@ import 'src/model.dart';
 
 export 'src/api.dart'
     show
+        BatchEmbedContentsResponse,
         BlockReason,
         Candidate,
         CitationMetadata,
         CitationSource,
         ContentEmbedding,
         CountTokensResponse,
+        EmbedContentRequest,
         EmbedContentResponse,
         FinishReason,
         GenerateContentResponse,

--- a/pkgs/google_generative_ai/lib/src/api.dart
+++ b/pkgs/google_generative_ai/lib/src/api.dart
@@ -88,6 +88,29 @@ final class EmbedContentResponse {
   EmbedContentResponse(this.embedding);
 }
 
+final class BatchEmbedContentsResponse {
+  /// The embeddings generated from the input content for each request, in the
+  /// same order as provided in the batch request.
+  final List<ContentEmbedding> embeddings;
+
+  BatchEmbedContentsResponse(this.embeddings);
+}
+
+final class EmbedContentRequest {
+  final Content content;
+  final TaskType? taskType;
+  final String? title;
+  final String? model;
+  EmbedContentRequest(this.content, {this.taskType, this.title, this.model});
+
+  Object toJson({String? defaultModel}) => {
+        'content': content.toJson(),
+        if (taskType case final taskType?) 'taskType': taskType.toJson(),
+        if (title != null) 'title': title,
+        if (model ?? defaultModel case final model?) 'model': model,
+      };
+}
+
 /// An embedding, as defined by a list of values.
 final class ContentEmbedding {
   /// The embedding values.
@@ -494,6 +517,17 @@ EmbedContentResponse parseEmbedContentResponse(Object jsonObject) {
   return switch (jsonObject) {
     {'embedding': final Object embedding} =>
       EmbedContentResponse(_parseContentEmbedding(embedding)),
+    {'error': final Object error} => throw parseError(error),
+    _ =>
+      throw FormatException('Unhandled EmbedContentResponse format', jsonObject)
+  };
+}
+
+BatchEmbedContentsResponse parseBatchEmbedContentsResponse(Object jsonObject) {
+  return switch (jsonObject) {
+    {'embeddings': final List<Object?> embeddings} =>
+      BatchEmbedContentsResponse(
+          embeddings.map(_parseContentEmbedding).toList()),
     {'error': final Object error} => throw parseError(error),
     _ =>
       throw FormatException('Unhandled EmbedContentResponse format', jsonObject)

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -215,8 +215,7 @@ final class GenerativeModel {
   /// Creates embeddings (list of float values) representing each content in
   /// [requests].
   ///
-  /// Sends a "batchEmbedContent" API request for the configured model,
-  /// and waits for the response.
+  /// Sends a "batchEmbedContents" API request for the configured model.
   ///
   /// Example:
   /// ```dart

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -211,6 +211,33 @@ final class GenerativeModel {
         await _client.makeRequest(_taskUri(Task.embedContent), parameters);
     return parseEmbedContentResponse(response);
   }
+
+  /// Creates embeddings (list of float values) representing each content in
+  /// [requests].
+  ///
+  /// Sends a "batchEmbedContent" API request for the configured model,
+  /// and waits for the response.
+  ///
+  /// Example:
+  /// ```dart
+  /// final requests = [
+  ///   EmbedContentRequest(Content.text(first)),
+  ///   EmbedContentRequest(Content.text(second))
+  /// ];
+  /// final promptEmbeddings =
+  ///     (await model.embedContent(requests)).embedding.values;
+  /// ```
+  Future<BatchEmbedContentsResponse> batchEmbedContents(
+      Iterable<EmbedContentRequest> requests) async {
+    final parameters = {
+      'requests': requests
+          .map((r) => r.toJson(defaultModel: '${_model.prefix}/${_model.name}'))
+          .toList()
+    };
+    final response = await _client.makeRequest(
+        _taskUri(Task.batchEmbedContents), parameters);
+    return parseBatchEmbedContentsResponse(response);
+  }
 }
 
 /// Creates a model with an overridden [ApiClient] for testing.

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -445,5 +445,55 @@ void main() {
                 EmbedContentResponse(ContentEmbedding([0.1, 0.2, 0.3]))));
       });
     });
+
+    group('batch embed contents', () {
+      test('can make successful request', () async {
+        final (client, model) = createModel();
+        final prompt1 = 'Some prompt';
+        final prompt2 = 'Another prompt';
+        final embedding1 = [0.1, 0.2, 0.3];
+        final embedding2 = [0.4, 0.5, 1.6];
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:batchEmbedContents'),
+          {
+            'requests': [
+              {
+                'content': {
+                  'role': 'user',
+                  'parts': [
+                    {'text': prompt1}
+                  ]
+                },
+                'model': 'models/$defaultModelName'
+              },
+              {
+                'content': {
+                  'role': 'user',
+                  'parts': [
+                    {'text': prompt2}
+                  ]
+                },
+                'model': 'models/$defaultModelName'
+              }
+            ]
+          },
+          {
+            'embeddings': [
+              {'values': embedding1},
+              {'values': embedding2}
+            ]
+          },
+        );
+        final response = await model.batchEmbedContents([
+          EmbedContentRequest(Content.text(prompt1)),
+          EmbedContentRequest(Content.text(prompt2))
+        ]);
+        expect(
+            response,
+            matchesBatchEmbedContentsResponse(BatchEmbedContentsResponse(
+                [ContentEmbedding(embedding1), ContentEmbedding(embedding2)])));
+      });
+    });
   });
 }

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -68,6 +68,11 @@ Matcher matchesEmbedContentResponse(EmbedContentResponse response) =>
     isA<EmbedContentResponse>().having(
         (r) => r.embedding, 'embedding', matchesEmbedding(response.embedding));
 
+Matcher matchesBatchEmbedContentsResponse(
+        BatchEmbedContentsResponse response) =>
+    isA<BatchEmbedContentsResponse>().having((r) => r.embeddings, 'embeddings',
+        response.embeddings.map(matchesEmbedding));
+
 Matcher matchesCountTokensResponse(CountTokensResponse response) =>
     isA<CountTokensResponse>()
         .having((r) => r.totalTokens, 'totalTokens', response.totalTokens);


### PR DESCRIPTION
Closes #96

This method was missed in the original implementation alongside
`embedContent`.
Add the overall model code when making requests without a model
specified - the back end requires the model field for batch requests.

- Add `BatchEmbedContentsResponse` and `EmbedContentRequest` classes and
  serialization.
- Add the `batchEmbedContents` model method. As with the other methods
  the top level `BatchEmbedContentsRequest` object fields are only
  exposed as the method arguments.
- Add a happy path test case and a matcher utility for batch embed
  responses.
