### PR TITLE
Add support for overriding API version

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4-wip
+
+- Allow specifying an API version.
+
 ## 0.2.3
 
 - Update the package version that is sent with the HTTP client name.

--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.4-wip
 
-- Allow specifying an API version.
+- Allow specifying an API version in a `requestOptions` argument when
+  constructing a model.
 
 ## 0.2.3
 

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -66,4 +66,4 @@ export 'src/error.dart'
         InvalidApiKey,
         ServerException,
         UnsupportedUserLocation;
-export 'src/model.dart' show GenerativeModel;
+export 'src/model.dart' show GenerativeModel, RequestOptions;

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -32,7 +32,15 @@ enum Task {
   batchEmbedContents;
 }
 
+/// Configuration for how a [GenerativeModel] makes requests.
+///
+/// This allows overriding the API version in use which may be required to use
+/// some beta features.
 final class RequestOptions {
+  /// The API version used to make requests.
+  ///
+  /// By default the version is `v1`. This may be specified as `v1beta` to use
+  /// beta features.
   final String? apiVersion;
   const RequestOptions({this.apiVersion});
 }

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -32,7 +32,7 @@ enum Task {
   batchEmbedContents;
 }
 
-class RequestOptions {
+final class RequestOptions {
   final String? apiVersion;
   const RequestOptions({this.apiVersion});
 }

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -48,8 +48,7 @@ final class GenerativeModel {
   final List<SafetySetting> _safetySettings;
   final GenerationConfig? _generationConfig;
   final ApiClient _client;
-  final RequestOptions? _requestOptions;
-  final Uri Function(RequestOptions?) _baseUri;
+  final Uri _baseUri;
 
   /// Create a [GenerativeModel] backed by the generative model named [model].
   ///
@@ -86,8 +85,7 @@ final class GenerativeModel {
         model: model,
         safetySettings: safetySettings,
         generationConfig: generationConfig,
-        baseUri: _googleAIBaseUri,
-        requestOptions: requestOptions,
+        baseUri: _googleAIBaseUri(requestOptions),
       );
 
   GenerativeModel._withClient({
@@ -95,14 +93,12 @@ final class GenerativeModel {
     required String model,
     required List<SafetySetting> safetySettings,
     required GenerationConfig? generationConfig,
-    required Uri Function(RequestOptions?) baseUri,
-    required RequestOptions? requestOptions,
+    required Uri baseUri,
   })  : _model = _normalizeModelName(model),
         _baseUri = baseUri,
         _safetySettings = safetySettings,
         _generationConfig = generationConfig,
-        _client = client,
-        _requestOptions = requestOptions;
+        _client = client;
 
   /// Returns the model code for a user friendly model name.
   ///
@@ -114,12 +110,9 @@ final class GenerativeModel {
     return (prefix: parts.first, name: parts.skip(1).join('/'));
   }
 
-  Uri _taskUri(Task task) {
-    final baseUri = _baseUri(_requestOptions);
-    return baseUri.replace(
-        pathSegments: baseUri.pathSegments
-            .followedBy([_model.prefix, '${_model.name}:${task.name}']));
-  }
+  Uri _taskUri(Task task) => _baseUri.replace(
+      pathSegments: _baseUri.pathSegments
+          .followedBy([_model.prefix, '${_model.name}:${task.name}']));
 
   /// Generates content responding to [prompt].
   ///
@@ -268,8 +261,7 @@ GenerativeModel createModelWithClient({
       model: model,
       safetySettings: safetySettings,
       generationConfig: generationConfig,
-      baseUri: _googleAIBaseUri,
-      requestOptions: requestOptions,
+      baseUri: _googleAIBaseUri(requestOptions),
     );
 
 /// Creates a model with an overridden base URL to communicate with a different
@@ -278,42 +270,15 @@ GenerativeModel createModelWithClient({
 /// Used from a `src/` import in the Vertex AI SDK.
 // TODO: https://github.com/google/generative-ai-dart/issues/111 - Changes to
 // this API need to be coordinated with the vertex AI SDK.
-GenerativeModel createModelWithBaseUri({
-  required String model,
-  required String apiKey,
-  required Uri baseUri,
-  List<SafetySetting> safetySettings = const [],
-  GenerationConfig? generationConfig,
-  RequestOptions? requestOptions,
-}) =>
+GenerativeModel createModelWithBaseUri(
+        {required String model,
+        required String apiKey,
+        required Uri baseUri,
+        List<SafetySetting> safetySettings = const [],
+        GenerationConfig? generationConfig}) =>
     GenerativeModel._withClient(
-      client: HttpApiClient(apiKey: apiKey),
-      model: model,
-      safetySettings: safetySettings,
-      generationConfig: generationConfig,
-      baseUri: (_) => baseUri,
-      requestOptions: requestOptions,
-    );
-
-/// Creates a model with an overridden base URL callback to communicate with a
-/// different backend.
-///
-/// Used from a `src/` import in the Vertex AI SDK.
-// TODO: https://github.com/google/generative-ai-dart/issues/111 - Changes to
-// this API need to be coordinated with the vertex AI SDK.
-GenerativeModel createModelWithVersionedBaseUri({
-  required String model,
-  required String apiKey,
-  required Uri Function(RequestOptions?) baseUri,
-  List<SafetySetting> safetySettings = const [],
-  GenerationConfig? generationConfig,
-  RequestOptions? requestOptions,
-}) =>
-    GenerativeModel._withClient(
-      client: HttpApiClient(apiKey: apiKey),
-      model: model,
-      safetySettings: safetySettings,
-      generationConfig: generationConfig,
-      baseUri: baseUri,
-      requestOptions: requestOptions,
-    );
+        client: HttpApiClient(apiKey: apiKey),
+        model: model,
+        safetySettings: safetySettings,
+        generationConfig: generationConfig,
+        baseUri: baseUri);

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.2.3';
+const packageVersion = '0.2.4-wip';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_generative_ai
-version: 0.2.3
+version: 0.2.4-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -24,9 +24,10 @@ void main() {
     const defaultModelName = 'some-model';
 
     (StubClient, GenerativeModel) createModel(
-        [String modelName = defaultModelName]) {
+        [String modelName = defaultModelName, RequestOptions? requestOptions]) {
       final client = StubClient();
-      final model = createModelWithClient(model: modelName, client: client);
+      final model = createModelWithClient(
+          model: modelName, client: client, requestOptions: requestOptions);
       return (client, model);
     }
 
@@ -76,6 +77,46 @@ void main() {
       client.stub(
         Uri.parse('https://generativelanguage.googleapis.com/v1/'
             'tunedModels/some-model:generateContent'),
+        {
+          'contents': [
+            {
+              'role': 'user',
+              'parts': [
+                {'text': prompt}
+              ]
+            }
+          ]
+        },
+        {
+          'candidates': [
+            {
+              'content': {
+                'role': 'model',
+                'parts': [
+                  {'text': result}
+                ]
+              }
+            }
+          ]
+        },
+      );
+      final response = await model.generateContent([Content.text(prompt)]);
+      expect(
+          response,
+          matchesGenerateContentResponse(GenerateContentResponse([
+            Candidate(
+                Content('model', [TextPart(result)]), null, null, null, null),
+          ], null)));
+    });
+
+    test('allows specifying an API version', () async {
+      final (client, model) = createModel(
+          defaultModelName, RequestOptions(apiVersion: 'override_version'));
+      final prompt = 'Some prompt';
+      final result = 'Some response';
+      client.stub(
+        Uri.parse('https://generativelanguage.googleapis.com/override_version/'
+            'models/some-model:generateContent'),
         {
           'contents': [
             {


### PR DESCRIPTION
This API will be required for authors to use to try function calling
while the backend support is still in version `v1beta`.

Add a RequestOptions class. For now this supports only the `apiVersion`
configuration. In the future this may add a `timeout` (#44) if implement
a deeper HTTP timeout functionality than `Future.timeout`.
