### PR TITLE
Add support for referring to uploaded files

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 0.2.4-wip
+## 0.3.0-wip
 
 - Allow specifying an API version in a `requestOptions` argument when
   constructing a model.
+- Add support for referring to uploaded files in request contents.
+- **Breaking** Added a new subclass `FilePart` of the sealed class `Part`.
 
 ## 0.2.3
 

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -59,7 +59,7 @@ export 'src/api.dart'
         SafetySetting,
         TaskType;
 export 'src/chat.dart' show ChatSession, StartChatExtension;
-export 'src/content.dart' show Content, DataPart, Part, TextPart;
+export 'src/content.dart' show Content, DataPart, FilePart, Part, TextPart;
 export 'src/error.dart'
     show
         GenerativeAIException,

--- a/pkgs/google_generative_ai/lib/src/chat.dart
+++ b/pkgs/google_generative_ai/lib/src/chat.dart
@@ -151,15 +151,14 @@ final class ChatSession {
 
     for (final content in contents) {
       for (final part in content.parts) {
-        switch (part) {
-          case TextPart(:final text):
-            if (text.isNotEmpty) {
-              previousText = textBuffer.isEmpty ? part : null;
-              textBuffer.write(text);
-            }
-          case DataPart():
-            addBufferedText();
-            parts.add(part);
+        if (part case TextPart(:final text)) {
+          if (text.isNotEmpty) {
+            previousText = textBuffer.isEmpty ? part : null;
+            textBuffer.write(text);
+          }
+        } else {
+          addBufferedText();
+          parts.add(part);
         }
       }
     }

--- a/pkgs/google_generative_ai/lib/src/content.dart
+++ b/pkgs/google_generative_ai/lib/src/content.dart
@@ -75,6 +75,7 @@ final class TextPart implements Part {
   Object toJson() => {'text': text};
 }
 
+/// A [Part] with the byte content of a file.
 final class DataPart implements Part {
   final String mimeType;
   final Uint8List bytes;
@@ -82,5 +83,17 @@ final class DataPart implements Part {
   @override
   Object toJson() => {
         'inlineData': {'data': base64Encode(bytes), 'mimeType': mimeType}
+      };
+}
+
+/// A [Part] referring to an uploaded file.
+///
+/// The [uri] should refer to a file uploaded to the Google AI File Service API.
+final class FilePart implements Part {
+  final Uri uri;
+  FilePart(this.uri);
+  @override
+  Object toJson() => {
+        'file_data': {'file_uri': '$uri'}
       };
 }

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.2.4-wip';
+const packageVersion = '0.3.0-wip';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_generative_ai
-version: 0.2.4-wip
+version: 0.3.0-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/utils/matchers.dart
+++ b/pkgs/google_generative_ai/test/utils/matchers.dart
@@ -26,6 +26,10 @@ Matcher matchesPart(Part part) => switch (part) {
           // TODO: When updating min SDK remove ignore.
           // ignore: unused_result, implementation bug
           .having((p) => p.bytes, 'bytes', bytes),
+      FilePart(uri: final uri) => isA<FilePart>()
+          // TODO: When updating min SDK remove ignore.
+          // ignore: unused_result, implementation bug
+          .having((p) => p.uri, 'uri', uri),
     };
 
 Matcher matchesContent(Content content) => isA<Content>()


### PR DESCRIPTION
Adding only the support to refer to files which for now need to be
uploaded separately.

- Add a `FilePart` subclass of `Part` with a Uri argument for a file
  uploaded to the google AI file service.
- Change an exhaustive switch on a `Part` to an if/else to avoid needing
  to update for further new subtypes of `Part`.
