### PR TITLE
Add support for system instructions

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for referring to uploaded files in request contents.
 - Add support for passing tools with functions the model may call while
   generating responses.
+- Add support for passing a system instruction when creating the model.
 - **Breaking** Added new subclasses `FilePart`, `FunctionCall`, and
   `FunctionResponse` of the sealed class `Part`.
 

--- a/pkgs/google_generative_ai/lib/src/content.dart
+++ b/pkgs/google_generative_ai/lib/src/content.dart
@@ -38,6 +38,8 @@ final class Content {
   static Content functionResponse(
           String name, Map<String, Object?>? response) =>
       Content('function', [FunctionResponse(name, response)]);
+  static Content system(String instructions) =>
+      Content('system', [TextPart(instructions)]);
 
   Map<String, Object?> toJson() => {
         if (role case final role?) 'role': role,


### PR DESCRIPTION
- Add a `systemInstruction` constructor argument on `GenerativeModel`.
  Accept the `Content` type instead of a String to directly match the
  REST API and to avoid breaking changes if the backend gains the
  flexibility to honor more than a single TextPart for system
  instructions.
- Add a `Content.system` utility with the single string argument to
  match the usage which works with the backend today.
