### PR TITLE
Implement constrained function calling

### DIFF
--- a/pkgs/google_generative_ai/CHANGELOG.md
+++ b/pkgs/google_generative_ai/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.1-wip
+
+- Add support on content generating methods for overriding "tools" passed when
+  the generative model was instantiated.
+- Add support for forcing the model to use or not use function calls to generate
+  content.
+
 ## 0.3.0
 
 - Allow specifying an API version in a `requestOptions` argument when

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -81,5 +81,6 @@ export 'src/function_calling.dart'
         FunctionDeclaration,
         Schema,
         SchemaType,
-        Tool;
+        Tool,
+        ToolConfig;
 export 'src/model.dart' show GenerativeModel, RequestOptions;

--- a/pkgs/google_generative_ai/lib/google_generative_ai.dart
+++ b/pkgs/google_generative_ai/lib/google_generative_ai.dart
@@ -75,5 +75,11 @@ export 'src/error.dart'
         ServerException,
         UnsupportedUserLocation;
 export 'src/function_calling.dart'
-    show FunctionDeclaration, Schema, SchemaType, Tool;
+    show
+        FunctionCallingConfig,
+        FunctionCallingMode,
+        FunctionDeclaration,
+        Schema,
+        SchemaType,
+        Tool;
 export 'src/model.dart' show GenerativeModel, RequestOptions;

--- a/pkgs/google_generative_ai/lib/src/function_calling.dart
+++ b/pkgs/google_generative_ai/lib/src/function_calling.dart
@@ -66,6 +66,54 @@ final class FunctionDeclaration {
       };
 }
 
+/// Configuration specifying how the model should use the functions provided as
+/// tools.
+final class FunctionCallingConfig {
+  /// The mode in which function calling should execute.
+  ///
+  /// If null, the default behavior will match [FunctionCallingMode.auto].
+  final FunctionCallingMode? mode;
+
+  /// A set of function names that, when provided, limits the functions the
+  /// model will call.
+  ///
+  /// This should only be set when the Mode is [FunctionCallingMode.any].
+  /// Function names should match [FunctionDeclaration.name]. With mode set to
+  /// `any`, model will predict a function call from the set of function names
+  /// provided.
+  final Set<String>? allowedFunctionNames;
+  FunctionCallingConfig({this.mode, this.allowedFunctionNames});
+
+  Object toJson() => {
+        if (mode case final mode?) 'mode': mode.toJson(),
+        if (allowedFunctionNames case final allowedFunctionNames?)
+          'allowedFunctionNames': allowedFunctionNames.toList(),
+      };
+}
+
+enum FunctionCallingMode {
+  /// The mode with default model behavior.
+  ///
+  /// Model decides to predict either a function call or a natural language
+  /// repspose.
+  auto,
+
+  /// A mode where the Model is constrained to always predicting a function
+  /// call only.
+  any,
+
+  /// A mode where the model will not predict any function call.
+  ///
+  /// Model behavior is same as when not passing any function declarations.
+  none;
+
+  String toJson() => switch (this) {
+        auto => 'AUTO',
+        any => 'ANY',
+        none => 'NONE',
+      };
+}
+
 /// The definition of an input or output data types.
 ///
 /// These types can be objects, but also primitives and arrays.

--- a/pkgs/google_generative_ai/lib/src/function_calling.dart
+++ b/pkgs/google_generative_ai/lib/src/function_calling.dart
@@ -66,6 +66,16 @@ final class FunctionDeclaration {
       };
 }
 
+final class ToolConfig {
+  final FunctionCallingConfig? functionCallingConfig;
+  ToolConfig({this.functionCallingConfig});
+
+  Map<String, Object?> toJson() => {
+        if (functionCallingConfig case final config?)
+          'functionCallingConfig': config.toJson(),
+      };
+}
+
 /// Configuration specifying how the model should use the functions provided as
 /// tools.
 final class FunctionCallingConfig {

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -87,7 +87,10 @@ final class GenerativeModel {
   ///
   /// Functions that the model may call while generating content can be passed
   /// in [tools]. When using tools [requestOptions] must be passed to
-  /// override the `apiVersion` to `v1beta`.
+  /// override the `apiVersion` to `v1beta`. Tool usage by the model can be
+  /// configured with [toolConfig]. Tools and tool configuration can be
+  /// overridden for individual requests with arguments to [generateContent] or
+  /// [generateContentStream].
   ///
   /// A [Content.system] can be passed to [systemInstruction] to give
   /// high priority instructions to the model. When using system instructions
@@ -151,6 +154,11 @@ final class GenerativeModel {
   /// Sends a "generateContent" API request for the configured model,
   /// and waits for the response.
   ///
+  /// The [safetySettings], [generationConfig], [tools], and [toolConfig],
+  /// override the arguments of the same name passed to the
+  /// [GenerativeModel.new] constructor. Each argument, when non-null,
+  /// overrides the model level configuration in its entirety.
+  ///
   /// Example:
   /// ```dart
   /// final response = await model.generateContent([Content.text(prompt)]);
@@ -187,6 +195,11 @@ final class GenerativeModel {
   ///
   /// Sends a "streamGenerateContent" API request for the configured model,
   /// and waits for the response.
+  ///
+  /// The [safetySettings], [generationConfig], [tools], and [toolConfig],
+  /// override the arguments of the same name passed to the
+  /// [GenerativeModel.new] constructor. Each argument, when non-null,
+  /// overrides the model level configuration in its entirety.
   ///
   /// Example:
   /// ```dart

--- a/pkgs/google_generative_ai/lib/src/model.dart
+++ b/pkgs/google_generative_ai/lib/src/model.dart
@@ -60,7 +60,7 @@ final class GenerativeModel {
   final ApiClient _client;
   final Uri _baseUri;
   final Content? _systemInstruction;
-  final FunctionCallingConfig? _functionCallingConfig;
+  final ToolConfig? _toolConfig;
 
   /// Create a [GenerativeModel] backed by the generative model named [model].
   ///
@@ -101,7 +101,7 @@ final class GenerativeModel {
     http.Client? httpClient,
     RequestOptions? requestOptions,
     Content? systemInstruction,
-    FunctionCallingConfig? functionCallingConfig,
+    ToolConfig? toolConfig,
   }) =>
       GenerativeModel._withClient(
         client: HttpApiClient(apiKey: apiKey, httpClient: httpClient),
@@ -111,7 +111,7 @@ final class GenerativeModel {
         baseUri: _googleAIBaseUri(requestOptions),
         tools: tools,
         systemInstruction: systemInstruction,
-        functionCallingConfig: functionCallingConfig,
+        toolConfig: toolConfig,
       );
 
   GenerativeModel._withClient({
@@ -122,14 +122,14 @@ final class GenerativeModel {
     required Uri baseUri,
     required List<Tool>? tools,
     required Content? systemInstruction,
-    required FunctionCallingConfig? functionCallingConfig,
+    required ToolConfig? toolConfig,
   })  : _model = _normalizeModelName(model),
         _baseUri = baseUri,
         _safetySettings = safetySettings,
         _generationConfig = generationConfig,
         _tools = tools,
         _systemInstruction = systemInstruction,
-        _functionCallingConfig = functionCallingConfig,
+        _toolConfig = toolConfig,
         _client = client;
 
   /// Returns the model code for a user friendly model name.
@@ -161,12 +161,12 @@ final class GenerativeModel {
     List<SafetySetting>? safetySettings,
     GenerationConfig? generationConfig,
     List<Tool>? tools,
-    FunctionCallingConfig? functionCallingConfig,
+    ToolConfig? toolConfig,
   }) async {
     safetySettings ??= _safetySettings;
     generationConfig ??= _generationConfig;
     tools ??= _tools;
-    functionCallingConfig ??= _functionCallingConfig;
+    toolConfig ??= _toolConfig;
     final parameters = {
       'contents': prompt.map((p) => p.toJson()).toList(),
       if (safetySettings.isNotEmpty)
@@ -174,8 +174,7 @@ final class GenerativeModel {
       if (generationConfig != null)
         'generationConfig': generationConfig.toJson(),
       if (tools != null) 'tools': tools.map((t) => t.toJson()).toList(),
-      if (functionCallingConfig != null)
-        'functionCallingConfig': functionCallingConfig.toJson(),
+      if (toolConfig != null) 'toolConfig': toolConfig.toJson(),
       if (_systemInstruction case final systemInstruction?)
         'systemInstruction': systemInstruction.toJson(),
     };
@@ -201,12 +200,12 @@ final class GenerativeModel {
     List<SafetySetting>? safetySettings,
     GenerationConfig? generationConfig,
     List<Tool>? tools,
-    FunctionCallingConfig? functionCallingConfig,
+    ToolConfig? toolConfig,
   }) {
     safetySettings ??= _safetySettings;
     generationConfig ??= _generationConfig;
     tools ??= _tools;
-    functionCallingConfig ??= _functionCallingConfig;
+    toolConfig ??= _toolConfig;
     final parameters = <String, Object?>{
       'contents': prompt.map((p) => p.toJson()).toList(),
       if (safetySettings.isNotEmpty)
@@ -214,8 +213,7 @@ final class GenerativeModel {
       if (generationConfig != null)
         'generationConfig': generationConfig.toJson(),
       if (tools != null) 'tools': tools.map((t) => t.toJson()).toList(),
-      if (functionCallingConfig != null)
-        'functionCallingConfig': functionCallingConfig.toJson(),
+      if (toolConfig != null) 'toolConfig': toolConfig.toJson(),
       if (_systemInstruction case final systemInstruction?)
         'systemInstruction': systemInstruction.toJson(),
     };
@@ -310,7 +308,7 @@ GenerativeModel createModelWithClient({
   RequestOptions? requestOptions,
   Content? systemInstruction,
   List<Tool>? tools,
-  FunctionCallingConfig? functionCallingConfig,
+  ToolConfig? toolConfig,
 }) =>
     GenerativeModel._withClient(
       client: client,
@@ -320,7 +318,7 @@ GenerativeModel createModelWithClient({
       baseUri: _googleAIBaseUri(requestOptions),
       systemInstruction: systemInstruction,
       tools: tools,
-      functionCallingConfig: functionCallingConfig,
+      toolConfig: toolConfig,
     );
 
 /// Creates a model with an overridden base URL to communicate with a different
@@ -345,5 +343,5 @@ GenerativeModel createModelWithBaseUri({
       baseUri: baseUri,
       systemInstruction: systemInstruction,
       tools: null,
-      functionCallingConfig: null,
+      toolConfig: null,
     );

--- a/pkgs/google_generative_ai/lib/src/version.dart
+++ b/pkgs/google_generative_ai/lib/src/version.dart
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const packageVersion = '0.3.0';
+const packageVersion = '0.3.1-wip';

--- a/pkgs/google_generative_ai/pubspec.yaml
+++ b/pkgs/google_generative_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_generative_ai
 # Update `lib/version.dart` when changing version.
-version: 0.3.0
+version: 0.3.1-wip
 description: >-
   The Google AI Dart SDK enables developers to use Google's state-of-the-art
   generative AI models (like Gemini).

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -27,6 +27,8 @@ void main() {
       String modelName = defaultModelName,
       RequestOptions? requestOptions,
       Content? systemInstruction,
+      List<Tool>? tools,
+      FunctionCallingConfig? functionCallingConfig,
     }) {
       final client = StubClient();
       final model = createModelWithClient(
@@ -34,6 +36,8 @@ void main() {
         client: client,
         requestOptions: requestOptions,
         systemInstruction: systemInstruction,
+        tools: tools,
+        functionCallingConfig: functionCallingConfig,
       );
       return (client, model);
     }
@@ -331,6 +335,140 @@ void main() {
         final response = await model.generateContent(
           [Content.text(prompt)],
         );
+        expect(
+            response,
+            matchesGenerateContentResponse(GenerateContentResponse([
+              Candidate(
+                  Content('model', [TextPart(result)]), null, null, null, null),
+            ], null)));
+      });
+
+      test('can pass tools and function calling config', () async {
+        final (client, model) = createModel(
+            tools: [
+              Tool(functionDeclarations: [
+                FunctionDeclaration('someFunction', 'Some cool function.',
+                    Schema(SchemaType.string, description: 'Some parameter.'))
+              ])
+            ],
+            functionCallingConfig: FunctionCallingConfig(
+                mode: FunctionCallingMode.any,
+                allowedFunctionNames: {'someFunction'}));
+        final prompt = 'Some prompt';
+        final result = 'Some response';
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:generateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ],
+            'tools': [
+              {
+                'functionDeclarations': [
+                  {
+                    'name': 'someFunction',
+                    'description': 'Some cool function.',
+                    'parameters': {
+                      'type': 'STRING',
+                      'description': 'Some parameter.'
+                    }
+                  }
+                ]
+              }
+            ],
+            'functionCallingConfig': {
+              'mode': 'ANY',
+              'allowedFunctionNames': ['someFunction'],
+            },
+          },
+          {
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': result}
+                  ]
+                }
+              }
+            ]
+          },
+        );
+        final response = await model.generateContent([Content.text(prompt)]);
+        expect(
+            response,
+            matchesGenerateContentResponse(GenerateContentResponse([
+              Candidate(
+                  Content('model', [TextPart(result)]), null, null, null, null),
+            ], null)));
+      });
+
+      test('can override tools and function calling config', () async {
+        final (client, model) = createModel();
+        final prompt = 'Some prompt';
+        final result = 'Some response';
+        client.stub(
+          Uri.parse('https://generativelanguage.googleapis.com/v1/'
+              'models/some-model:generateContent'),
+          {
+            'contents': [
+              {
+                'role': 'user',
+                'parts': [
+                  {'text': prompt}
+                ]
+              }
+            ],
+            'tools': [
+              {
+                'functionDeclarations': [
+                  {
+                    'name': 'someFunction',
+                    'description': 'Some cool function.',
+                    'parameters': {
+                      'type': 'STRING',
+                      'description': 'Some parameter.'
+                    }
+                  }
+                ]
+              }
+            ],
+            'functionCallingConfig': {
+              'mode': 'ANY',
+              'allowedFunctionNames': ['someFunction'],
+            },
+          },
+          {
+            'candidates': [
+              {
+                'content': {
+                  'role': 'model',
+                  'parts': [
+                    {'text': result}
+                  ]
+                }
+              }
+            ]
+          },
+        );
+        final response = await model.generateContent([
+          Content.text(prompt)
+        ],
+            tools: [
+              Tool(functionDeclarations: [
+                FunctionDeclaration('someFunction', 'Some cool function.',
+                    Schema(SchemaType.string, description: 'Some parameter.'))
+              ])
+            ],
+            functionCallingConfig: FunctionCallingConfig(
+                mode: FunctionCallingMode.any,
+                allowedFunctionNames: {'someFunction'}));
         expect(
             response,
             matchesGenerateContentResponse(GenerateContentResponse([

--- a/pkgs/google_generative_ai/test/generative_model_test.dart
+++ b/pkgs/google_generative_ai/test/generative_model_test.dart
@@ -28,7 +28,7 @@ void main() {
       RequestOptions? requestOptions,
       Content? systemInstruction,
       List<Tool>? tools,
-      FunctionCallingConfig? functionCallingConfig,
+      ToolConfig? toolConfig,
     }) {
       final client = StubClient();
       final model = createModelWithClient(
@@ -37,7 +37,7 @@ void main() {
         requestOptions: requestOptions,
         systemInstruction: systemInstruction,
         tools: tools,
-        functionCallingConfig: functionCallingConfig,
+        toolConfig: toolConfig,
       );
       return (client, model);
     }
@@ -351,9 +351,10 @@ void main() {
                     Schema(SchemaType.string, description: 'Some parameter.'))
               ])
             ],
-            functionCallingConfig: FunctionCallingConfig(
-                mode: FunctionCallingMode.any,
-                allowedFunctionNames: {'someFunction'}));
+            toolConfig: ToolConfig(
+                functionCallingConfig: FunctionCallingConfig(
+                    mode: FunctionCallingMode.any,
+                    allowedFunctionNames: {'someFunction'})));
         final prompt = 'Some prompt';
         final result = 'Some response';
         client.stub(
@@ -382,9 +383,11 @@ void main() {
                 ]
               }
             ],
-            'functionCallingConfig': {
-              'mode': 'ANY',
-              'allowedFunctionNames': ['someFunction'],
+            'toolConfig': {
+              'functionCallingConfig': {
+                'mode': 'ANY',
+                'allowedFunctionNames': ['someFunction'],
+              }
             },
           },
           {
@@ -439,9 +442,11 @@ void main() {
                 ]
               }
             ],
-            'functionCallingConfig': {
-              'mode': 'ANY',
-              'allowedFunctionNames': ['someFunction'],
+            'toolConfig': {
+              'functionCallingConfig': {
+                'mode': 'ANY',
+                'allowedFunctionNames': ['someFunction'],
+              }
             },
           },
           {
@@ -466,9 +471,10 @@ void main() {
                     Schema(SchemaType.string, description: 'Some parameter.'))
               ])
             ],
-            functionCallingConfig: FunctionCallingConfig(
-                mode: FunctionCallingMode.any,
-                allowedFunctionNames: {'someFunction'}));
+            toolConfig: ToolConfig(
+                functionCallingConfig: FunctionCallingConfig(
+                    mode: FunctionCallingMode.any,
+                    allowedFunctionNames: {'someFunction'})));
         expect(
             response,
             matchesGenerateContentResponse(GenerateContentResponse([


### PR DESCRIPTION
Function calling configuration allows specifying that the model must, or
must not, call a function on the current response. By default the model
is allowed to choose whether to call a function or reply in natural
language.

Add a `ToolConfig` class and a `toolConfig` argument to the
`GenerativeModel` constructor and the methods for generating content.
The classes and fields match the API model directly.

Add support for overriding the `tools` for a specific generate content
call from what was set during instantiation.
